### PR TITLE
Rename some things to match Initial API Spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The goal is to allow this kind of queries :
 
 ```graphql
 query me {
-  post @restAPI(type: "Post", endPoint: "/post/1") {
+  post @rest(type: "Post", endPoint: "/post/1") {
     id
     title
   }
@@ -26,14 +26,14 @@ So that you can first use your REST API and adopt incrementally GraphQL on your 
 
 Of course you do not get all the benefits of graphQL by using this package :
 
-* Multiples requests are send when multiple `@restAPI` directives are found.
+* Multiples requests are send when multiple `@rest` directives are found.
 * You get all the fields from your REST endpoints : filtering is done client side.
 
 ## Example Queries
 
 ```graphql
 query postTitle {
-  post @restAPI(type: "Post", endPoint: "/post/1") {
+  post @rest(type: "Post", endPoint: "/post/1") {
     id
     title
   }
@@ -54,7 +54,7 @@ You can pass a variable to a query
 
 ```graphql
 query postTitle($id: ID!) {
-  post(id: $id) @restAPI(type: "Post", endPoint: "/post/:id") {
+  post(id: $id) @rest(type: "Post", endPoint: "/post/:id") {
     id
     title
   }
@@ -66,11 +66,11 @@ You can make multiple calls in a query
 
 ```graphql
 query postAndTags {
-  post @restAPI(type: "Post", endPoint: "/post/1") {
+  post @rest(type: "Post", endPoint: "/post/1") {
     id
     title
   }
-  tags @restAPI(type: "Tag", endPoint: "/tags") {
+  tags @rest(type: "Tag", endPoint: "/tags") {
     name
   }
 }
@@ -86,7 +86,7 @@ import RestLink from 'rest-api-link';
 const APILink = new RestLink({ uri: 'example.com/api' });
 
 const tagsQuery = gql`query tags {
-  tags @restAPI(type: "Tag", endPoint: "/tags") {
+  tags @rest(type: "Tag", endPoint: "/tags") {
     name
   }
 }`;

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The goal is to allow this kind of queries :
 
 ```graphql
 query me {
-  post @rest(type: "Post", endPoint: "/post/1") {
+  post @rest(type: "Post", endpoint: "/post/1") {
     id
     title
   }
@@ -33,7 +33,7 @@ Of course you do not get all the benefits of graphQL by using this package :
 
 ```graphql
 query postTitle {
-  post @rest(type: "Post", endPoint: "/post/1") {
+  post @rest(type: "Post", endpoint: "/post/1") {
     id
     title
   }
@@ -54,7 +54,7 @@ You can pass a variable to a query
 
 ```graphql
 query postTitle($id: ID!) {
-  post(id: $id) @rest(type: "Post", endPoint: "/post/:id") {
+  post(id: $id) @rest(type: "Post", endpoint: "/post/:id") {
     id
     title
   }
@@ -66,11 +66,11 @@ You can make multiple calls in a query
 
 ```graphql
 query postAndTags {
-  post @rest(type: "Post", endPoint: "/post/1") {
+  post @rest(type: "Post", endpoint: "/post/1") {
     id
     title
   }
-  tags @rest(type: "Tag", endPoint: "/tags") {
+  tags @rest(type: "Tag", endpoint: "/tags") {
     name
   }
 }
@@ -86,7 +86,7 @@ import RestLink from 'rest-api-link';
 const APILink = new RestLink({ uri: 'example.com/api' });
 
 const tagsQuery = gql`query tags {
-  tags @rest(type: "Tag", endPoint: "/tags") {
+  tags @rest(type: "Tag", endpoint: "/tags") {
     name
   }
 }`;

--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ Please look into the *.test file to see cases we can handle.
 ## Usage
 
 ```js
-import RestAPILink from 'rest-api-link';
+import RestLink from 'rest-api-link';
 
-const APILink = new RestAPILink({ uri: 'example.com/api' });
+const APILink = new RestLink({ uri: 'example.com/api' });
 
 const tagsQuery = gql`query tags {
   tags @restAPI(type: "Tag", endPoint: "/tags") {

--- a/src/rest-api-link.js
+++ b/src/rest-api-link.js
@@ -10,9 +10,9 @@ const getTypeNameFromDirective = directive => {
   return typeArgument.value.value;
 }
 
-const getEndPointFromDirective = directive => {
-  const endPointArgument = directive.arguments.filter(argument => argument.name.value === 'endPoint')[0];
-  return endPointArgument.value.value;
+const getEndpointFromDirective = directive => {
+  const endpointArgument = directive.arguments.filter(argument => argument.name.value === 'endpoint')[0];
+  return endpointArgument.value.value;
 }
 
 const getSelectionName = selection => selection.name.value;
@@ -24,17 +24,17 @@ const getQueryParams = selection =>
     value: p.value.value
   }));
 
-const replaceParam = (endPoint, name, value) => {
+const replaceParam = (endpoint, name, value) => {
   if(!value || !name) {
-    return endPoint;
+    return endpoint;
   }
-  return endPoint.replace(`:${name}`, value)
+  return endpoint.replace(`:${name}`, value)
 }
 
-const replaceParamsInsideEndPoints = (endPoint, queryParams, variables) => {
-  const endPointWithQueryParams = queryParams.reduce((acc, { name, value }) => replaceParam(acc, name, value), endPoint);
-  const endPointWithInputVariables = Object.keys(variables).reduce((acc, e) => replaceParam(acc, e, variables[e]), endPointWithQueryParams);
-  return endPointWithInputVariables;
+const replaceParamsInsideEndpoints = (endpoint, queryParams, variables) => {
+  const endpointWithQueryParams = queryParams.reduce((acc, { name, value }) => replaceParam(acc, name, value), endpoint);
+  const endpointWithInputVariables = Object.keys(variables).reduce((acc, e) => replaceParam(acc, e, variables[e]), endpointWithQueryParams);
+  return endpointWithInputVariables;
 };
 
 const getRequests = (selections, variables, uri) =>
@@ -42,15 +42,15 @@ const getRequests = (selections, variables, uri) =>
     const selectionName = getSelectionName(selection);
     const filteredKeys = getResultKeys(selection); 
     const directive = getRestDirective(selection);
-    const endPoint = getEndPointFromDirective(directive);
+    const endpoint = getEndpointFromDirective(directive);
     const __typename = getTypeNameFromDirective(directive);
     const queryParams = getQueryParams(selection);
-    const endPointWithParams = replaceParamsInsideEndPoints(endPoint, queryParams, variables);
+    const endpointWithParams = replaceParamsInsideEndpoints(endpoint, queryParams, variables);
 
     return {
       name: selectionName,
       filteredKeys,
-      endPoint: `${uri}${endPointWithParams}`,
+      endpoint: `${uri}${endpointWithParams}`,
       __typename
     };
   });
@@ -69,9 +69,9 @@ const filterResultWithKeys = (result, keys) => {
   return filterObjectWithKeys(result, keys);
 };
 
-const processRequest = ({ name, filteredKeys, endPoint, __typename }) =>
+const processRequest = ({ name, filteredKeys, endpoint, __typename }) =>
   new Promise((resolve, reject) => {
-    fetch(endPoint)
+    fetch(endpoint)
       .then(res => res.json())
       .then(data => {
         const dataFiltered = filterResultWithKeys(data, filteredKeys);

--- a/src/rest-api-link.js
+++ b/src/rest-api-link.js
@@ -90,7 +90,7 @@ async function processRequests(requestsParams) {
   }
 }
 
-class RestAPILink extends ApolloLink {
+class RestLink extends ApolloLink {
   constructor({ uri }) {
     super();
     this.uri = uri;
@@ -120,4 +120,4 @@ class RestAPILink extends ApolloLink {
   }
 }
 
-export default RestAPILink;
+export default RestLink;

--- a/src/rest-api-link.js
+++ b/src/rest-api-link.js
@@ -3,7 +3,7 @@ import { hasDirectives, getQueryDefinition } from "apollo-utilities";
 import { filterObjectWithKeys, ArrayToObject } from './utils';
 
 const getRestDirective = selection => selection.directives.filter(directive => 
-      (directive.kind === 'Directive' && directive.name.value === 'restAPI'))[0]
+      (directive.kind === 'Directive' && directive.name.value === 'rest'))[0]
 
 const getTypeNameFromDirective = directive => {
   const typeArgument = directive.arguments.filter(argument => argument.name.value === 'type' )[0];
@@ -98,7 +98,7 @@ class RestLink extends ApolloLink {
 
   request(operation) {
     const { query } = operation;
-    const isRestQuery = hasDirectives(["restAPI"], operation.query);
+    const isRestQuery = hasDirectives(["rest"], operation.query);
     if (!isRestQuery) {
       // should we forward the request ?
     }

--- a/src/rest-api-link.test.js
+++ b/src/rest-api-link.test.js
@@ -17,7 +17,7 @@ describe('Query single calls', () => {
 
     const postTitleQuery = gql`
       query postTitle {
-        post @restAPI(type: "Post", endPoint: "/post/1") {
+        post @rest(type: "Post", endPoint: "/post/1") {
           id
           title
         }
@@ -42,7 +42,7 @@ describe('Query single calls', () => {
       fetchMock.get("/api/post/1", post);
 
       const postTitleQuery = gql`query postTitle {
-          post @restAPI(endPoint: "/post/1", type: "Post") {
+          post @rest(endPoint: "/post/1", type: "Post") {
             id
             title
           }
@@ -65,7 +65,7 @@ describe('Query single calls', () => {
     fetchMock.get("/api/tags", tags);
 
     const tagsQuery = gql`query tags {
-        tags @restAPI(type: "[Tag]", endPoint: "/tags") {
+        tags @rest(type: "[Tag]", endPoint: "/tags") {
           name
         }
       }`;
@@ -88,7 +88,7 @@ describe('Query single calls', () => {
     fetchMock.get("/api/post/1", post);
 
     const postTitleQuery = gql`query postTitle {
-        post @restAPI(type: "Post", endPoint: "/post/1") {
+        post @rest(type: "Post", endPoint: "/post/1") {
           id
           title
         }
@@ -111,7 +111,7 @@ describe('Query single calls', () => {
     fetchMock.get("/api/post/1", post);
 
     const postTitleQuery = gql`query postTitle {
-        post(id: "1") @restAPI(type: "Post", endPoint: "/post/:id") {
+        post(id: "1") @rest(type: "Post", endPoint: "/post/:id") {
           id
           title
         }
@@ -134,7 +134,7 @@ describe('Query single calls', () => {
     fetchMock.get("/api/post/1", post);
 
     const postTitleQuery = gql`query postTitle($id: ID!) {
-        post(id: $id) @restAPI(type: "Post", endPoint: "/post/:id") {
+        post(id: $id) @rest(type: "Post", endPoint: "/post/:id") {
           id
           title
         }
@@ -170,11 +170,11 @@ describe("Query multiple calls", () => {
 
     const postAndTags = gql`
       query postAndTags {
-        post @restAPI(type: "Post", endPoint: "/post/1") {
+        post @rest(type: "Post", endPoint: "/post/1") {
           id
           title
         }
-        tags @restAPI(type: "[Tag]", endPoint: "/tags") {
+        tags @rest(type: "[Tag]", endPoint: "/tags") {
           name
         }
       }

--- a/src/rest-api-link.test.js
+++ b/src/rest-api-link.test.js
@@ -1,7 +1,7 @@
 import { execute, makePromise } from 'apollo-link'
 import gql from 'graphql-tag'
 import fetchMock from 'fetch-mock'
-import RestAPILink from './rest-api-link'
+import RestLink from './rest-api-link'
 
 describe('Query single calls', () => {
   afterEach(() => {
@@ -11,7 +11,7 @@ describe('Query single calls', () => {
   it('can run a simple query', async () => {
     expect.assertions(1)
 
-    const link = new RestAPILink({ uri: "/api" });
+    const link = new RestLink({ uri: "/api" });
     const post = { id: '1', title: 'Love apollo' };
     fetchMock.get('/api/post/1', post);
 
@@ -37,7 +37,7 @@ describe('Query single calls', () => {
     it("can get query params regardless of the order", async () => {
       expect.assertions(1);
 
-      const link = new RestAPILink({ uri: "/api" });
+      const link = new RestLink({ uri: "/api" });
       const post = { id: "1", title: "Love apollo" };
       fetchMock.get("/api/post/1", post);
 
@@ -59,7 +59,7 @@ describe('Query single calls', () => {
   it("can return array result with typename", async () => {
     expect.assertions(1);
 
-    const link = new RestAPILink({ uri: "/api" });
+    const link = new RestLink({ uri: "/api" });
 
     const tags = [{ name: "apollo" }, { name: "grapql" }];
     fetchMock.get("/api/tags", tags);
@@ -82,7 +82,7 @@ describe('Query single calls', () => {
   it("can filter the query result", async () => {
     expect.assertions(1);
 
-    const link = new RestAPILink({ uri: "/api" });
+    const link = new RestLink({ uri: "/api" });
 
     const post = { id: "1", title: "Love apollo", content: "Best graphql client ever." };
     fetchMock.get("/api/post/1", post);
@@ -105,7 +105,7 @@ describe('Query single calls', () => {
   it("can pass param to a query without a variable", async () => {
     expect.assertions(1);
 
-    const link = new RestAPILink({ uri: "/api" });
+    const link = new RestLink({ uri: "/api" });
 
     const post = { id: "1", title: "Love apollo" };
     fetchMock.get("/api/post/1", post);
@@ -128,7 +128,7 @@ describe('Query single calls', () => {
   it("can pass param to a query with a variable", async () => {
     expect.assertions(1);
 
-    const link = new RestAPILink({ uri: "/api" });
+    const link = new RestLink({ uri: "/api" });
 
     const post = { id: "1", title: "Love apollo" };
     fetchMock.get("/api/post/1", post);
@@ -159,7 +159,7 @@ describe("Query multiple calls", () => {
   it("can run a query with multiple rest calls", async () => {
     expect.assertions(2);
 
-    const link = new RestAPILink({ uri: "/api" });
+    const link = new RestLink({ uri: "/api" });
 
     const post = { id: "1", title: "Love apollo" };
     fetchMock.get("/api/post/1", post);

--- a/src/rest-api-link.test.js
+++ b/src/rest-api-link.test.js
@@ -17,7 +17,7 @@ describe('Query single calls', () => {
 
     const postTitleQuery = gql`
       query postTitle {
-        post @rest(type: "Post", endPoint: "/post/1") {
+        post @rest(type: "Post", endpoint: "/post/1") {
           id
           title
         }
@@ -42,7 +42,7 @@ describe('Query single calls', () => {
       fetchMock.get("/api/post/1", post);
 
       const postTitleQuery = gql`query postTitle {
-          post @rest(endPoint: "/post/1", type: "Post") {
+          post @rest(endpoint: "/post/1", type: "Post") {
             id
             title
           }
@@ -65,7 +65,7 @@ describe('Query single calls', () => {
     fetchMock.get("/api/tags", tags);
 
     const tagsQuery = gql`query tags {
-        tags @rest(type: "[Tag]", endPoint: "/tags") {
+        tags @rest(type: "[Tag]", endpoint: "/tags") {
           name
         }
       }`;
@@ -88,7 +88,7 @@ describe('Query single calls', () => {
     fetchMock.get("/api/post/1", post);
 
     const postTitleQuery = gql`query postTitle {
-        post @rest(type: "Post", endPoint: "/post/1") {
+        post @rest(type: "Post", endpoint: "/post/1") {
           id
           title
         }
@@ -111,7 +111,7 @@ describe('Query single calls', () => {
     fetchMock.get("/api/post/1", post);
 
     const postTitleQuery = gql`query postTitle {
-        post(id: "1") @rest(type: "Post", endPoint: "/post/:id") {
+        post(id: "1") @rest(type: "Post", endpoint: "/post/:id") {
           id
           title
         }
@@ -134,7 +134,7 @@ describe('Query single calls', () => {
     fetchMock.get("/api/post/1", post);
 
     const postTitleQuery = gql`query postTitle($id: ID!) {
-        post(id: $id) @rest(type: "Post", endPoint: "/post/:id") {
+        post(id: $id) @rest(type: "Post", endpoint: "/post/:id") {
           id
           title
         }
@@ -170,11 +170,11 @@ describe("Query multiple calls", () => {
 
     const postAndTags = gql`
       query postAndTags {
-        post @rest(type: "Post", endPoint: "/post/1") {
+        post @rest(type: "Post", endpoint: "/post/1") {
           id
           title
         }
-        tags @rest(type: "[Tag]", endPoint: "/tags") {
+        tags @rest(type: "[Tag]", endpoint: "/tags") {
           name
         }
       }


### PR DESCRIPTION
This PR implements the following subtasks from #3 

- [x] update directive naming to be `@rest`
- [x] update Link Class name to be `RestLink` instead of `RestAPILink`
- [x] update `endPoint` to be `endpoint`