### PR TITLE
Add an endpoints map!

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ npm link
 
 # in the project you want to run this in
 npm link apollo-link-rest
-```
+```js

--- a/designs/initial.md
+++ b/designs/initial.md
@@ -2,7 +2,7 @@
 
 ### Arguments
 
-- route: path to rest endpoint. This could be a path or a full url. If a path, add to the endpoint given on link creation or from the context
+- path: path to rest endpoint. This could be a path or a full url. If a path, add to the endpoint given on link creation or from the context is concatenated to it.
 - params: a map of variables to url params
 - method: the HTTP method to send the request via (i.e GET, PUT, POST)
 - type: The GraphQL type this will return
@@ -26,11 +26,11 @@ These are the same semantics that will be supported on the server, but when used
 ```js
 const QUERY = gql`
   query RestData($email: String!) {
-    users @rest(route: '/users/email/:email', params: { email: $email }, method: 'GET', type: 'User') {
+    users @rest(path: '/users/email/:email', params: { email: $email }, method: 'GET', type: 'User') {
       id @export(as: "id")
       firstName
       lastName
-      friends @rest(route: '/friends/:id', params: { id: $id }, type: '[User]') {
+      friends @rest(path: '/friends/:id', params: { id: $id }, type: '[User]') {
         firstName
         lastName
       }
@@ -46,7 +46,7 @@ const QUERY = gql`
 
 - `fetch`: an optional implementation of `fetch` (see the http-link for api / warnings). Will use global if found
 - `fieldNameNormalizer`: a function that takes the response field name and turns into a GraphQL compliant name,for instance "MyFieldName:IsGreat" => myFieldNameIsGreat
-- `endpoint`: a root endpoint (uri) to apply routes to: i.e. http[s]://api.example.com/v1 or a map of endpoints with a key to choose in the directive
+- `endpoint`: a root endpoint (uri) to apply paths to: i.e. http[s]://api.example.com/v1 or a map of endpoints with a key to choose in the directive
 - `batch`: a boolean to batch possible calls together (not inital version requirement!)
 - `headers`: an object representing values to be sent as headers on the request
 - `credentials`: a string representing the credentials policy you want for the fetch call

--- a/designs/initial.md
+++ b/designs/initial.md
@@ -14,6 +14,8 @@ It's important that the rest directive could be used at any depth in a query, bu
 
 ## `@export` directive
 
+The export directive re-exposes a field for use in a later (nested) query. An example use-case would be getting a list of users, and hitting a different endpoint to fetch more data using the exported field in the REST query args.
+
 ### Arguments
 - as: the string name to create this as a variable to be used down the selection set
 
@@ -44,7 +46,7 @@ const QUERY = gql`
 
 - `fetch`: an optional implementation of `fetch` (see the http-link for api / warnings). Will use global if found
 - `fieldNameNormalizer`: a function that takes the response field name and turns into a GraphQL compliant name,for instance "MyFieldName:IsGreat" => myFieldNameIsGreat
-- `endpoint`: a root endpoint to apply routes to: i.e. api.example.com/v1 or a map of endpoints with a key to choose in the directive
+- `endpoint`: a root endpoint (uri) to apply routes to: i.e. http[s]://api.example.com/v1 or a map of endpoints with a key to choose in the directive
 - `batch`: a boolean to batch possible calls together (not inital version requirement!)
 - `headers`: an object representing values to be sent as headers on the request
 - `credentials`: a string representing the credentials policy you want for the fetch call

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -15,12 +15,21 @@ const getTypeNameFromDirective = directive => {
   return typeArgument.value.value;
 };
 
+const getRouteFromDirective = directive => {
+  const routeArgument = directive.arguments.filter(argument => argument.name.value === 'route')[0] || {};
+  return (routeArgument.value || {}).value;
+}
+
 const getEndpointFromDirective = directive => {
   const endpointArgument = directive.arguments.filter(
     argument => argument.name.value === 'endpoint',
-  )[0];
-  return endpointArgument.value.value;
-};
+  )[0] || {};
+  return (endpointArgument.value || {}).value;
+}
+
+const getURIFromEndpoints = (endpoints, endpoint) => {
+  return endpoints[endpoint || DEFAULT_ENDPOINT_KEY] || endpoints[DEFAULT_ENDPOINT_KEY];
+}
 
 const getSelectionName = selection => selection.name.value;
 const getResultKeys = selection =>
@@ -39,10 +48,10 @@ const replaceParam = (endpoint, name, value) => {
   return endpoint.replace(`:${name}`, value);
 };
 
-const replaceParamsInsideEndpoints = (endpoint, queryParams, variables) => {
+const replaceParamsInsideRoute = (fullRoute, queryParams, variables) => {
   const endpointWithQueryParams = queryParams.reduce(
     (acc, { name, value }) => replaceParam(acc, name, value),
-    endpoint,
+    fullRoute,
   );
   const endpointWithInputVariables = Object.keys(variables).reduce(
     (acc, e) => replaceParam(acc, e, variables[e]),
@@ -51,16 +60,20 @@ const replaceParamsInsideEndpoints = (endpoint, queryParams, variables) => {
   return endpointWithInputVariables;
 };
 
-const getRequests = (selections, variables, uri) =>
+const getRequests = (selections, variables, endpoints) =>
   selections.map(selection => {
     const selectionName = getSelectionName(selection);
     const filteredKeys = getResultKeys(selection);
     const directive = getRestDirective(selection);
-    const endpoint = getEndpointFromDirective(directive);
+    const endpoint = getEndpointFromDirective(directive) || "";
+    const route = getRouteFromDirective(directive) || "";
     const __typename = getTypeNameFromDirective(directive);
     const queryParams = getQueryParams(selection);
+
+    const uri = getURIFromEndpoints(endpoints, endpoint);
+    const fullRoute = uri + route;
     const endpointWithParams = replaceParamsInsideEndpoints(
-      endpoint,
+      fullRoute,
       queryParams,
       variables,
     );
@@ -68,7 +81,7 @@ const getRequests = (selections, variables, uri) =>
     return {
       name: selectionName,
       filteredKeys,
-      endpoint: `${uri}${endpointWithParams}`,
+      endpoint: `${endpointAndRouteWithParams}`,
       __typename,
     };
   });
@@ -107,12 +120,38 @@ async function processRequests(requestsParams) {
     throw new Error(error);
   }
 }
+/**
+ * Default key to use when the @rest directive omits the "endpoint" parameter.
+ */
+const DEFAULT_ENDPOINT_KEY = "";
 
+/**
+ * RestLink is an apollo-link for communicating with REST services using GraphQL on the client-side
+ * - @param: uri: default URI, optional if endpoints provides a default.
+ * - @param: endpoints: optional map of potential API endpoints this RestLink will hit.
+ */
 export class RestLink extends ApolloLink {
-  private uri: string;
-  constructor({ uri }) {
+  private endpoints: { [endpointKey: string]: string };
+  constructor({ uri, endpoints }) {
     super();
-    this.uri = uri;
+    const fallback = {};
+    fallback[DEFAULT_ENDPOINT_KEY] = uri || '';
+    this.endpoints = Object.assign({}, endpoints || fallback);
+
+    if (uri == null && endpoints == null) {
+      throw new Error("A RestLink must be initialized with either 1 uri, or a map of keyed-endpoints");
+    }
+    if (uri != null) {
+      const currentDefaultURI = (endpoints || {})[DEFAULT_ENDPOINT_KEY];
+      if (currentDefaultURI != null && currentDefaultURI != uri) {
+        throw new Error("RestLink was configured with a default uri that doesn't match what's passed in to the endpoints map.");
+      }
+      this.endpoints[DEFAULT_ENDPOINT_KEY] == uri;
+    }
+    
+    // if (this.endpoints[DEFAULT_ENDPOINT_KEY] == null) {
+    //   console.warn("RestLink configured without a default URI. All @rest(…) directives must provide an endpoint key!");
+    // }
   }
 
   request(operation) {
@@ -126,7 +165,7 @@ export class RestLink extends ApolloLink {
       const queryDefinition = getQueryDefinition(query);
       const { variables } = operation;
       const { selectionSet: { selections } } = queryDefinition;
-      const requestsParams = getRequests(selections, variables, this.uri);
+      const requestsParams = getRequests(selections, variables, this.endpoints);
 
       try {
         const result = processRequests(requestsParams);


### PR DESCRIPTION
This implements these subtasks from #3 
- [x] split concept of `endpoint` for the `@rest(…` directive, and name it `route:` for the server path (without the host).
- [x] support map of imports with `endpoint:` optional parameter for people who have more than one RestLink