### PR TITLE
Add support for passing query method

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "trailingComma": "all",
+  "singleQuote": true
+}

--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -3,6 +3,7 @@ import gql from 'graphql-tag';
 import * as fetchMock from 'fetch-mock';
 
 import { RestLink } from '../';
+import { validateRequestMethodForOperationType } from '../restLink';
 
 describe('Configuration Errors', () => {
   it('throws without any config', () => {
@@ -397,6 +398,39 @@ describe('Query options', () => {
       }
 
       expect(fetchMock.called('/api/post/1')).toBe(false);
+    });
+  });
+});
+
+describe('validateRequestMethodForOperationType', () => {
+  const createRequestParams = (params = {}) => ({
+    name: 'post',
+    filteredKeys: [],
+    endpoint: `/api/post/1`,
+    method: 'POST',
+    __typename: 'Post',
+    ...params,
+  });
+  describe('for operation type "mutation"', () => {
+    it('throws because it is not supported yet', () => {
+      expect.assertions(1);
+      expect(() =>
+        validateRequestMethodForOperationType(
+          [createRequestParams()],
+          'mutation',
+        ),
+      ).toThrowError('A "mutation" operation is not supported yet.');
+    });
+  });
+  describe('for operation type "subscription"', () => {
+    it('throws because it is not supported yet', () => {
+      expect.assertions(1);
+      expect(() =>
+        validateRequestMethodForOperationType(
+          [createRequestParams()],
+          'subscription',
+        ),
+      ).toThrowError('A "subscription" operation is not supported yet.');
     });
   });
 });

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -154,7 +154,7 @@ async function processRequests(requestsParams) {
   }
 }
 
-const validateRequestMethodForOperationType = (
+export const validateRequestMethodForOperationType = (
   requestParams: Array<RequestParam>,
   operationType: OperationTypeNode,
 ) => {


### PR DESCRIPTION
Refs: #3

* adds a `getMethodFromDirective` to extract the `method` from the `rest` directive and pass it to `fetch`
  * default method is set to `GET`
* validates usage of HTTP methods based on the operation type
  * `query` should only support `GET` methods
  * `mutation` should support all other HTTP methods (`POST`, `PUT`, etc)
    * as far as I can see, `mutation` is not supported yet, so we just throw an error
  * `subscription` (I guess this can be ignored, we should probably forbid the usage of the `rest` directive for subscription)

Extras:
* `.prettierrc`, to ensure correct formatting
* defined some _types_