### PR TITLE
Graphql anywhere - logic rewritten

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "watch": "tsc -w -p ."
   },
   "dependencies": {
-    "apollo-link": "^1.0.3"
+    "apollo-link": "^1.0.3",
+    "graphql-anywhere": "^4.1.0-alpha.0"
   },
   "peerDependencies": {
     "graphql": "0.11.7"

--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -300,6 +300,41 @@ describe('Query multiple calls', () => {
     expect(data.post).toBeDefined();
     expect(data.tags).toBeDefined();
   });
+
+  it('can run a subquery with multiple rest calls', async () => {
+    expect.assertions(2);
+    ``;
+
+    const link = new RestLink({ uri: '/api' });
+
+    const post = { id: '1', title: 'Love apollo' };
+    fetchMock.get('/api/post/1', post);
+
+    const tags = [{ name: 'apollo' }, { name: 'graphql' }];
+    fetchMock.get('/api/tags', tags);
+
+    const postAndTags = gql`
+      query postAndTags {
+        post @rest(type: "Post", path: "/post/1") {
+          id
+          title
+          tags @rest(type: "[Tag]", path: "/tags") {
+            name
+          }
+        }
+      }
+    `;
+
+    const data = await makePromise(
+      execute(link, {
+        operationName: 'postAndTags',
+        query: postAndTags,
+      }),
+    );
+
+    expect(data.post).toBeDefined();
+    expect(data.post.tags).toBeDefined();
+  });
 });
 
 describe('Query options', () => {

--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -609,21 +609,11 @@ describe('Query options', () => {
 });
 
 describe('validateRequestMethodForOperationType', () => {
-  const createRequestParams = (params = {}) => ({
-    name: 'post',
-    filteredKeys: [],
-    endpoint: `/api/post/1`,
-    method: 'POST',
-    ...params,
-  });
   describe('for operation type "mutation"', () => {
     it('throws because it is not supported yet', () => {
       expect.assertions(1);
       expect(() =>
-        validateRequestMethodForOperationType(
-          [createRequestParams()],
-          'mutation',
-        ),
+        validateRequestMethodForOperationType('POST', 'mutation'),
       ).toThrowError('A "mutation" operation is not supported yet.');
     });
   });
@@ -631,10 +621,7 @@ describe('validateRequestMethodForOperationType', () => {
     it('throws because it is not supported yet', () => {
       expect.assertions(1);
       expect(() =>
-        validateRequestMethodForOperationType(
-          [createRequestParams()],
-          'subscription',
-        ),
+        validateRequestMethodForOperationType('POST', 'subscription'),
       ).toThrowError('A "subscription" operation is not supported yet.');
     });
   });

--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -96,7 +96,7 @@ describe('Query single calls', () => {
       }),
     );
 
-    expect(data).toMatchObject({ post: { ...post, __typename: 'Post' } });
+    expect(data).toMatchObject({ post });
   });
 
   it('can return array result with typename', async () => {
@@ -122,7 +122,10 @@ describe('Query single calls', () => {
       }),
     );
 
-    const tagsWithTypeName = tags.map(tag => ({ ...tag, __typename: '[Tag]' }));
+    const tagsWithTypeName = tags.map(tag => ({
+      ...tag,
+      __typename: '[Tag]',
+    }));
     expect(data).toMatchObject({ tags: tagsWithTypeName });
   });
 
@@ -254,7 +257,7 @@ describe('Query single calls', () => {
     );
 
     expect(data1.post.title).toBe(postV1.title);
-    expect(data2.post.title).toBe(postV2.title);
+    expect(data2.post.titleText).toBe(postV2.titleText);
   });
 });
 
@@ -539,7 +542,6 @@ describe('validateRequestMethodForOperationType', () => {
     filteredKeys: [],
     endpoint: `/api/post/1`,
     method: 'POST',
-    __typename: 'Post',
     ...params,
   });
   describe('for operation type "mutation"', () => {

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -67,9 +67,9 @@ export const validateRequestMethodForOperationType = (
 };
 
 const resolver = async (fieldName, root, args, context, info) => {
-  const { directives, isLeaf } = info;
+  const { directives, isLeaf, resultKey } = info;
   if (isLeaf) {
-    return root[fieldName];
+    return root[resultKey];
   }
   const { endpoints, headers } = context;
   const { path, endpoint } = directives.rest;

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -7,7 +7,6 @@ import {
   FetchResult,
 } from 'apollo-link';
 import { hasDirectives, addTypenameToDocument } from 'apollo-utilities';
-import { print } from 'graphql/language/printer';
 import { graphql } from 'graphql-anywhere/lib/async';
 
 export type RestLinkOptions = {

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -1,7 +1,14 @@
 import { OperationTypeNode } from 'graphql';
-import { ApolloLink, Observable } from 'apollo-link';
-import { hasDirectives, getQueryDefinition } from 'apollo-utilities';
-import { filterObjectWithKeys, ArrayToObject } from './utils';
+import {
+  ApolloLink,
+  Observable,
+  Operation,
+  NextLink,
+  FetchResult,
+} from 'apollo-link';
+import { hasDirectives, addTypenameToDocument } from 'apollo-utilities';
+import { print } from 'graphql/language/printer';
+import { graphql } from 'graphql-anywhere/lib/async';
 
 export type RestLinkOptions = {
   uri: string;
@@ -13,48 +20,11 @@ export type RestLinkOptions = {
   };
 };
 
-type RequestParam = {
-  name: string;
-  filteredKeys: Array<string>;
-  endpoint: string;
-  method: string;
-  __typename: string;
-};
-
-const getRestDirective = selection =>
-  selection.directives.filter(
-    directive =>
-      directive.kind === 'Directive' && directive.name.value === 'rest',
-  )[0];
-
-const getTypeNameFromDirective = directive => {
-  const typeArgument = directive.arguments.filter(
-    argument => argument.name.value === 'type',
-  )[0];
-  return typeArgument.value.value;
-};
-
-const getPathFromDirective = directive => {
-  const pathArgument =
-    directive.arguments.filter(argument => argument.name.value === 'path')[0] ||
-    {};
-  return (pathArgument.value || {}).value;
-};
-
-const getMethodFromDirective = directive => {
-  const pathArgument =
-    directive.arguments.filter(
-      argument => argument.name.value === 'method',
-    )[0] || {};
-  return (pathArgument.value || {}).value;
-};
-
-const getEndpointFromDirective = directive => {
-  const endpointArgument =
-    directive.arguments.filter(
-      argument => argument.name.value === 'endpoint',
-    )[0] || {};
-  return (endpointArgument.value || {}).value;
+const addTypeNameToResult = (result, __typename) => {
+  if (Array.isArray(result)) {
+    return result.map(e => ({ ...e, __typename }));
+  }
+  return { ...result, __typename };
 };
 
 const getURIFromEndpoints = (endpoints, endpoint) => {
@@ -64,16 +34,6 @@ const getURIFromEndpoints = (endpoints, endpoint) => {
   );
 };
 
-const getSelectionName = selection => selection.name.value;
-const getResultKeys = (selection): Array<string> =>
-  selection.selectionSet.selections.map(({ name }) => name.value);
-
-const getQueryParams = selection =>
-  selection.arguments.map(p => ({
-    name: p.name.value,
-    value: p.value.value,
-  }));
-
 const replaceParam = (endpoint, name, value) => {
   if (!value || !name) {
     return endpoint;
@@ -81,116 +41,59 @@ const replaceParam = (endpoint, name, value) => {
   return endpoint.replace(`:${name}`, value);
 };
 
-const replaceParamsInsidePath = (fullPath, queryParams, variables) => {
-  const endpointWithQueryParams = queryParams.reduce(
-    (acc, { name, value }) => replaceParam(acc, name, value),
-    fullPath,
-  );
-  const endpointWithInputVariables = Object.keys(variables).reduce(
-    (acc, e) => replaceParam(acc, e, variables[e]),
-    endpointWithQueryParams,
-  );
-  return endpointWithInputVariables;
-};
-
-const getRequests = (selections, variables, endpoints): Array<RequestParam> =>
-  selections.map(selection => {
-    const selectionName = getSelectionName(selection);
-    const filteredKeys = getResultKeys(selection);
-    const directive = getRestDirective(selection);
-    const endpoint = getEndpointFromDirective(directive) || '';
-    const path = getPathFromDirective(directive) || '';
-    const method = getMethodFromDirective(directive) || 'GET';
-    const __typename = getTypeNameFromDirective(directive);
-    const queryParams = getQueryParams(selection);
-
-    const uri = getURIFromEndpoints(endpoints, endpoint);
-
-    const fullPath = uri + path;
-    const endpointAndPathWithParams = replaceParamsInsidePath(
-      fullPath,
-      queryParams,
-      variables,
-    );
-
-    return {
-      name: selectionName,
-      filteredKeys,
-      endpoint: `${endpointAndPathWithParams}`,
-      method,
-      __typename,
-    };
-  });
-
-const addTypeNameToResult = (result, __typename) => {
-  if (Array.isArray(result)) {
-    return result.map(e => ({ ...e, __typename }));
-  }
-  return { ...result, __typename };
-};
-
-const filterResultWithKeys = (result, keys) => {
-  if (Array.isArray(result)) {
-    return result.map(elem => filterObjectWithKeys(elem, keys));
-  }
-  return filterObjectWithKeys(result, keys);
-};
-
-const processRequest = ({
-  name,
-  filteredKeys,
-  endpoint,
-  method,
-  headers,
-  __typename,
-}) =>
-  new Promise((resolve, reject) => {
-    fetch(endpoint, { method, headers })
-      .then(res => res.json())
-      .then(data => {
-        const dataFiltered = filterResultWithKeys(data, filteredKeys);
-        resolve({ [name]: addTypeNameToResult(dataFiltered, __typename) });
-      })
-      .catch(reject);
-  });
-
-async function processRequests(requestsParams) {
-  const requests = requestsParams.map(processRequest);
-  try {
-    const requestsResults = await Promise.all(requests);
-    return ArrayToObject(requestsResults);
-  } catch (error) {
-    throw new Error(error);
-  }
-}
-
 export const validateRequestMethodForOperationType = (
-  requestParams: Array<RequestParam>,
+  method: String,
   operationType: OperationTypeNode,
 ) => {
   /**
    * NOTE: possible improvements
    * - use typed errors (e.g. ValidationError, MethodNotSupportedError)
-   * - validate all requests before throwing the error
    */
-  requestParams.forEach(({ method }) => {
-    switch (operationType) {
-      case 'query':
-        if (method.toUpperCase() !== 'GET') {
-          throw new Error(
-            `A "query" operation can only support "GET" requests but got "${method}".`,
-          );
-        }
-        return;
-      case 'mutation':
-        throw new Error('A "mutation" operation is not supported yet.');
-      case 'subscription':
-        throw new Error('A "subscription" operation is not supported yet.');
-      default:
-        // ignore
-        return;
+  switch (operationType) {
+    case 'query':
+      if (method.toUpperCase() !== 'GET') {
+        throw new Error(
+          `A "query" operation can only support "GET" requests but got "${method}".`,
+        );
+      }
+      return;
+    case 'mutation':
+      throw new Error('A "mutation" operation is not supported yet.');
+    case 'subscription':
+      throw new Error('A "subscription" operation is not supported yet.');
+    default:
+      // ignore
+      return;
+  }
+};
+
+const resolver = async (fieldName, root, args, context, info) => {
+  const { directives, isLeaf } = info;
+  if (isLeaf) {
+    return root[fieldName];
+  }
+  const { endpoints, headers } = context;
+  const { path, endpoint } = directives.rest;
+  const uri = getURIFromEndpoints(endpoints, endpoint);
+  try {
+    let pathWithParams = path;
+    if (args) {
+      pathWithParams = Object.keys(args).reduce(
+        (acc, e) => replaceParam(acc, e, args[e]),
+        path,
+      );
     }
-  });
+    let { method, type } = directives.rest;
+    if (!method) {
+      method = 'GET';
+    }
+    validateRequestMethodForOperationType(method, 'query');
+    return await fetch(`${uri}${pathWithParams}`, { method, headers })
+      .then(res => res.json())
+      .then(result => addTypeNameToResult(result, type));
+  } catch (error) {
+    throw error;
+  }
 };
 
 /**
@@ -227,44 +130,41 @@ export class RestLink extends ApolloLink {
       this.endpoints[DEFAULT_ENDPOINT_KEY] == uri;
     }
 
-    // if (this.endpoints[DEFAULT_ENDPOINT_KEY] == null) {
-    //   console.warn("RestLink configured without a default URI. All @rest(…) directives must provide an endpoint key!");
-    // }
+    if (this.endpoints[DEFAULT_ENDPOINT_KEY] == null) {
+      console.warn(
+        'RestLink configured without a default URI. All @rest(…) directives must provide an endpoint key!',
+      );
+    }
 
     this.headers = headers || {};
   }
 
-  request(operation) {
-    const { query } = operation;
+  public request(
+    operation: Operation,
+    forward?: NextLink,
+  ): Observable<FetchResult> | null {
+    const { query, variables } = operation;
     const isRestQuery = hasDirectives(['rest'], operation.query);
     if (!isRestQuery) {
-      // should we forward the request ?
+      return forward(operation);
     }
+
+    const headers = {
+      ...this.headers,
+      ...(operation.getContext().headers || {}),
+    };
+
+    const queryWithTypename = addTypenameToDocument(query);
+
     return new Observable(observer => {
-      // for now doing query only
-      const queryDefinition = getQueryDefinition(query);
-      const { variables } = operation;
-      const { selectionSet: { selections } } = queryDefinition;
-      const { headers: headersFromContext } = operation.getContext();
-      const requestsParams = getRequests(
-        selections,
-        variables,
-        this.endpoints,
-      ).map(params => ({
-        ...params,
-        headers: {
-          ...this.headers,
-          ...(headersFromContext || {}),
-        },
-      }));
-
-      validateRequestMethodForOperationType(
-        requestsParams,
-        queryDefinition.operation,
-      );
-
       try {
-        const result = processRequests(requestsParams);
+        const result = graphql(
+          resolver,
+          queryWithTypename,
+          null,
+          { headers, endpoints: this.endpoints },
+          variables,
+        );
         observer.next(result);
         observer.complete();
       } catch (err) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,0 @@
-export const ArrayToObject = array =>
-  array.reduce((result, elem) => ({ ...result, ...elem }), {});
-
-export const filterObjectWithKeys = (obj, keys) =>
-  keys.reduce((acc, e) => {
-    acc[e] = obj[e];
-    return acc;
-  }, {});


### PR DESCRIPTION
This PR uses `graphql-anywhere` package to resolve queries.

This allow us to have a more reliable Link, for example the [graphql aliases](https://github.com/apollographql/apollo-link-rest/issues/7) bug is now gone.

What I love is that RestLink has now fewer lines than before :) and the `utils` file has been deleted.

You can write nested queries, which was not possible before, for example : 

```graphql
query postAndTags {
        post @rest(type: "Post", path: "/post/1") {
          id
          title
          tags @rest(type: "[Tag]", path: "/tags") {
            name
          }
        }
      }
```

I will add more tests soon ( fragments for example )