### PR TITLE
Field name normalizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "apollo-link-http": "1.2.0",
     "browserify": "14.5.0",
     "bundlesize": "0.15.3",
+    "camelcase": "^4.1.0",
     "codecov": "3.0.0",
     "danger": "1.2.0",
     "fetch-mock": "^5.13.1",

--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -1,416 +1,234 @@
 import { execute, makePromise, ApolloLink } from 'apollo-link';
 import gql from 'graphql-tag';
+import * as camelCase from 'camelcase';
 import * as fetchMock from 'fetch-mock';
 
 import { RestLink } from '../';
 import { validateRequestMethodForOperationType } from '../restLink';
 
-describe('Configuration Errors', () => {
-  it('throws without any config', () => {
-    expect.assertions(3);
+describe('Configuration', () => {
+  describe('Errors', () => {
+    it('throws without any config', () => {
+      expect.assertions(3);
 
-    expect(() => {
-      new RestLink();
-    }).toThrow();
-    expect(() => {
-      new RestLink({});
-    }).toThrow();
-    expect(() => {
-      new RestLink({ bogus: '' });
-    }).toThrow();
-  });
-
-  it('throws with mismatched config', () => {
-    expect.assertions(1);
-    expect(() => {
-      new RestLink({ uri: '/correct', endpoints: { '': '/mismatched' } });
-    }).toThrow();
-  });
-
-  it("Doesn't throw on good configs", () => {
-    expect.assertions(1);
-
-    new RestLink({ uri: '/correct' });
-    new RestLink({ uri: '/correct', endpoints: { other: '/other' } });
-    new RestLink({
-      uri: '/correct',
-      endpoints: { '': '/correct', other: '/other' },
+      expect(() => {
+        new RestLink();
+      }).toThrow();
+      expect(() => {
+        new RestLink({});
+      }).toThrow();
+      expect(() => {
+        new RestLink({ bogus: '' });
+      }).toThrow();
     });
-    new RestLink({ endpoints: { '': '/correct', other: '/other' } });
 
-    expect(true).toBe(true);
-  });
-});
+    it('throws with mismatched config', () => {
+      expect.assertions(1);
+      expect(() => {
+        new RestLink({ uri: '/correct', endpoints: { '': '/mismatched' } });
+      }).toThrow();
+    });
 
-describe('Query single calls', () => {
-  afterEach(() => {
-    fetchMock.restore();
-  });
+    it("Doesn't throw on good configs", () => {
+      expect.assertions(1);
 
-  it('can run a simple query', async () => {
-    expect.assertions(1);
+      new RestLink({ uri: '/correct' });
+      new RestLink({ uri: '/correct', endpoints: { other: '/other' } });
+      new RestLink({
+        uri: '/correct',
+        endpoints: { '': '/correct', other: '/other' },
+      });
+      new RestLink({ endpoints: { '': '/correct', other: '/other' } });
 
-    const link = new RestLink({ uri: '/api' });
-    const post = { id: '1', title: 'Love apollo' };
-    fetchMock.get('/api/post/1', post);
-
-    const postTitleQuery = gql`
-      query postTitle {
-        post @rest(type: "Post", path: "/post/1") {
-          id
-          title
-        }
-      }
-    `;
-
-    const data = await makePromise(
-      execute(link, {
-        operationName: 'postTitle',
-        query: postTitleQuery,
-      }),
-    );
-
-    expect(data).toMatchObject({ post: { ...post, __typename: 'Post' } });
+      expect(true).toBe(true);
+    });
   });
 
-  it('can get query params regardless of the order', async () => {
-    expect.assertions(1);
+  describe('Field name normalizer', () => {
+    afterEach(() => {
+      fetchMock.restore();
+    });
+    it('should apply fieldNameNormalizer if specified', async () => {
+      expect.assertions(2);
+      const link = new RestLink({
+        uri: '/api',
+        fieldNameNormalizer: camelCase,
+      });
+      const post = { id: '1', Title: 'Love apollo' };
+      fetchMock.get('/api/post/1', post);
 
-    const link = new RestLink({ uri: '/api' });
-    const post = { id: '1', title: 'Love apollo' };
-    fetchMock.get('/api/post/1', post);
+      const tags = [{ Name: 'apollo' }, { Name: 'graphql' }];
+      fetchMock.get('/api/tags', tags);
 
-    const postTitleQuery = gql`
-      query postTitle {
-        post @rest(path: "/post/1", type: "Post") {
-          id
-          title
-        }
-      }
-    `;
-
-    const data = await makePromise(
-      execute(link, {
-        operationName: 'postTitle',
-        query: postTitleQuery,
-      }),
-    );
-
-    expect(data).toMatchObject({ post });
-  });
-
-  it('can return array result with typename', async () => {
-    expect.assertions(1);
-
-    const link = new RestLink({ uri: '/api' });
-
-    const tags = [{ name: 'apollo' }, { name: 'graphql' }];
-    fetchMock.get('/api/tags', tags);
-
-    const tagsQuery = gql`
-      query tags {
-        tags @rest(type: "[Tag]", path: "/tags") {
-          name
-        }
-      }
-    `;
-
-    const data = await makePromise(
-      execute(link, {
-        operationName: 'tags',
-        query: tagsQuery,
-      }),
-    );
-
-    const tagsWithTypeName = tags.map(tag => ({
-      ...tag,
-      __typename: '[Tag]',
-    }));
-    expect(data).toMatchObject({ tags: tagsWithTypeName });
-  });
-
-  it('can filter the query result', async () => {
-    expect.assertions(1);
-
-    const link = new RestLink({ uri: '/api' });
-
-    const post = {
-      id: '1',
-      title: 'Love apollo',
-      content: 'Best graphql client ever.',
-    };
-    fetchMock.get('/api/post/1', post);
-
-    const postTitleQuery = gql`
-      query postTitle {
-        post @rest(type: "Post", path: "/post/1") {
-          id
-          title
-        }
-      }
-    `;
-
-    const data = await makePromise(
-      execute(link, {
-        operationName: 'postWithContent',
-        query: postTitleQuery,
-      }),
-    );
-
-    expect(data.post.content).toBeUndefined();
-  });
-
-  it('can pass param to a query without a variable', async () => {
-    expect.assertions(1);
-
-    const link = new RestLink({ uri: '/api' });
-    const post = { id: '1', title: 'Love apollo' };
-    fetchMock.get('/api/post/1', post);
-
-    const postTitleQuery = gql`
-      query postTitle {
-        post @rest(type: "Post", path: "/post/1") {
-          id
-          title
-        }
-      }
-    `;
-
-    const data = await makePromise(
-      execute(link, {
-        operationName: 'postTitle',
-        query: postTitleQuery,
-      }),
-    );
-
-    expect(data).toMatchObject({ post: { ...post, __typename: 'Post' } });
-  });
-
-  it('can pass param to a query with a variable', async () => {
-    expect.assertions(1);
-
-    const link = new RestLink({ uri: '/api' });
-
-    const post = { id: '1', title: 'Love apollo' };
-    fetchMock.get('/api/post/1', post);
-
-    const postTitleQuery = gql`
-      query postTitle {
-        post(id: "1") @rest(type: "Post", path: "/post/:id") {
-          id
-          title
-        }
-      }
-    `;
-
-    const data = await makePromise(
-      execute(link, {
-        operationName: 'postTitle',
-        query: postTitleQuery,
-        variables: { id: '1' },
-      }),
-    );
-
-    expect(data.post.title).toBe(post.title);
-  });
-
-  it('can hit two endpoints!', async () => {
-    expect.assertions(2);
-
-    const link = new RestLink({ endpoints: { v1: '/v1', v2: '/v2' } });
-
-    const postV1 = { id: '1', title: '1. Love apollo' };
-    const postV2 = { id: '1', titleText: '2. Love apollo' };
-    fetchMock.get('/v1/post/1', postV1);
-    fetchMock.get('/v2/post/1', postV2);
-
-    const postTitleQuery1 = gql`
-      query postTitle($id: ID!) {
-        post(id: $id) @rest(type: "Post", path: "/post/:id", endpoint: "v1") {
-          id
-          title
-        }
-      }
-    `;
-    const postTitleQuery2 = gql`
-      query postTitle($id: ID!) {
-        post(id: $id) @rest(type: "Post", path: "/post/:id", endpoint: "v2") {
-          id
-          titleText
-        }
-      }
-    `;
-
-    const data1 = await makePromise(
-      execute(link, {
-        operationName: 'postTitle1',
-        query: postTitleQuery1,
-        variables: { id: '1' },
-      }),
-    );
-    const data2 = await makePromise(
-      execute(link, {
-        operationName: 'postTitle2',
-        query: postTitleQuery2,
-        variables: { id: '1' },
-      }),
-    );
-
-    expect(data1.post.title).toBe(postV1.title);
-    expect(data2.post.titleText).toBe(postV2.titleText);
-  });
-});
-
-describe('Query multiple calls', () => {
-  afterEach(() => {
-    fetchMock.restore();
-  });
-
-  it('can run a query with multiple rest calls', async () => {
-    expect.assertions(2);
-    ``;
-
-    const link = new RestLink({ uri: '/api' });
-
-    const post = { id: '1', title: 'Love apollo' };
-    fetchMock.get('/api/post/1', post);
-
-    const tags = [{ name: 'apollo' }, { name: 'graphql' }];
-    fetchMock.get('/api/tags', tags);
-
-    const postAndTags = gql`
-      query postAndTags {
-        post @rest(type: "Post", path: "/post/1") {
-          id
-          title
-        }
-        tags @rest(type: "[Tag]", path: "/tags") {
-          name
-        }
-      }
-    `;
-
-    const data = await makePromise(
-      execute(link, {
-        operationName: 'postAndTags',
-        query: postAndTags,
-      }),
-    );
-
-    expect(data.post).toBeDefined();
-    expect(data.tags).toBeDefined();
-  });
-
-  it('can run a subquery with multiple rest calls', async () => {
-    expect.assertions(2);
-    ``;
-
-    const link = new RestLink({ uri: '/api' });
-
-    const post = { id: '1', title: 'Love apollo' };
-    fetchMock.get('/api/post/1', post);
-
-    const tags = [{ name: 'apollo' }, { name: 'graphql' }];
-    fetchMock.get('/api/tags', tags);
-
-    const postAndTags = gql`
-      query postAndTags {
-        post @rest(type: "Post", path: "/post/1") {
-          id
-          title
-          tags @rest(type: "[Tag]", path: "/tags") {
-            name
+      const postAndTags = gql`
+        query postAndTags {
+          post @rest(type: "Post", path: "/post/1") {
+            id
+            Title
+            Tags @rest(type: "[Tag]", path: "/tags") {
+              Name
+            }
           }
         }
-      }
-    `;
+      `;
 
-    const data = await makePromise(
-      execute(link, {
-        operationName: 'postAndTags',
-        query: postAndTags,
-      }),
-    );
+      const data = await makePromise(
+        execute(link, {
+          operationName: 'postTitle',
+          query: postAndTags,
+        }),
+      );
 
-    expect(data.post).toBeDefined();
-    expect(data.post.tags).toBeDefined();
+      expect(data.post.title).toBeDefined();
+      expect(data.post.tags[0].name).toBeDefined();
+    });
   });
 
-  +it('GraphQL aliases should work', async () => {
-    expect.assertions(2);
+  describe('Query single calls', () => {
+    afterEach(() => {
+      fetchMock.restore();
+    });
 
-    const link = new RestLink({ endpoints: { v1: '/v1', v2: '/v2' } });
-
-    const postV1 = { id: '1', title: '1. Love apollo' };
-    const postV2 = { id: '1', titleText: '2. Love apollo' };
-    fetchMock.get('/v1/post/1', postV1);
-    fetchMock.get('/v2/post/1', postV2);
-
-    const postTitleQueries = gql`
-      query postTitle($id: ID!) {
-        v1: post(id: $id)
-          @rest(type: "Post", path: "/post/:id", endpoint: "v1") {
-          id
-          title
-        }
-        v2: post(id: $id)
-          @rest(type: "Post", path: "/post/:id", endpoint: "v2") {
-          id
-          titleText
-        }
-      }
-    `;
-
-    const data = await makePromise(
-      execute(link, {
-        operationName: 'postTitle',
-        query: postTitleQueries,
-        variables: { id: '1' },
-      }),
-    );
-
-    expect(data.v1.title).toBe(postV1.title);
-    expect(data.v2.titleText).toBe(postV2.titleText);
-  });
-});
-
-describe('Query options', () => {
-  afterEach(() => {
-    fetchMock.restore();
-  });
-  describe('method', () => {
-    it('works for GET requests', async () => {
+    it('can run a simple query', async () => {
       expect.assertions(1);
 
       const link = new RestLink({ uri: '/api' });
-
       const post = { id: '1', title: 'Love apollo' };
       fetchMock.get('/api/post/1', post);
 
       const postTitleQuery = gql`
         query postTitle {
-          post(id: "1") @rest(type: "Post", path: "/post/:id", method: "GET") {
+          post @rest(type: "Post", path: "/post/1") {
             id
             title
           }
         }
       `;
 
-      await makePromise(
+      const data = await makePromise(
         execute(link, {
           operationName: 'postTitle',
           query: postTitleQuery,
-          variables: { id: '1' },
         }),
       );
 
-      const requestCall = fetchMock.calls('/api/post/1')[0];
-      expect(requestCall[1]).toEqual(
-        expect.objectContaining({ method: 'GET' }),
-      );
+      expect(data).toMatchObject({ post: { ...post, __typename: 'Post' } });
     });
 
-    it('works without specifying a request method', async () => {
+    it('can get query params regardless of the order', async () => {
+      expect.assertions(1);
+
+      const link = new RestLink({ uri: '/api' });
+      const post = { id: '1', title: 'Love apollo' };
+      fetchMock.get('/api/post/1', post);
+
+      const postTitleQuery = gql`
+        query postTitle {
+          post @rest(path: "/post/1", type: "Post") {
+            id
+            title
+          }
+        }
+      `;
+
+      const data = await makePromise(
+        execute(link, {
+          operationName: 'postTitle',
+          query: postTitleQuery,
+        }),
+      );
+
+      expect(data).toMatchObject({ post });
+    });
+
+    it('can return array result with typename', async () => {
+      expect.assertions(1);
+
+      const link = new RestLink({ uri: '/api' });
+
+      const tags = [{ name: 'apollo' }, { name: 'graphql' }];
+      fetchMock.get('/api/tags', tags);
+
+      const tagsQuery = gql`
+        query tags {
+          tags @rest(type: "[Tag]", path: "/tags") {
+            name
+          }
+        }
+      `;
+
+      const data = await makePromise(
+        execute(link, {
+          operationName: 'tags',
+          query: tagsQuery,
+        }),
+      );
+
+      const tagsWithTypeName = tags.map(tag => ({
+        ...tag,
+        __typename: '[Tag]',
+      }));
+      expect(data).toMatchObject({ tags: tagsWithTypeName });
+    });
+
+    it('can filter the query result', async () => {
+      expect.assertions(1);
+
+      const link = new RestLink({ uri: '/api' });
+
+      const post = {
+        id: '1',
+        title: 'Love apollo',
+        content: 'Best graphql client ever.',
+      };
+      fetchMock.get('/api/post/1', post);
+
+      const postTitleQuery = gql`
+        query postTitle {
+          post @rest(type: "Post", path: "/post/1") {
+            id
+            title
+          }
+        }
+      `;
+
+      const data = await makePromise(
+        execute(link, {
+          operationName: 'postWithContent',
+          query: postTitleQuery,
+        }),
+      );
+
+      expect(data.post.content).toBeUndefined();
+    });
+
+    it('can pass param to a query without a variable', async () => {
+      expect.assertions(1);
+
+      const link = new RestLink({ uri: '/api' });
+      const post = { id: '1', title: 'Love apollo' };
+      fetchMock.get('/api/post/1', post);
+
+      const postTitleQuery = gql`
+        query postTitle {
+          post @rest(type: "Post", path: "/post/1") {
+            id
+            title
+          }
+        }
+      `;
+
+      const data = await makePromise(
+        execute(link, {
+          operationName: 'postTitle',
+          query: postTitleQuery,
+        }),
+      );
+
+      expect(data).toMatchObject({ post: { ...post, __typename: 'Post' } });
+    });
+
+    it('can pass param to a query with a variable', async () => {
       expect.assertions(1);
 
       const link = new RestLink({ uri: '/api' });
@@ -427,7 +245,7 @@ describe('Query options', () => {
         }
       `;
 
-      await makePromise(
+      const data = await makePromise(
         execute(link, {
           operationName: 'postTitle',
           query: postTitleQuery,
@@ -435,30 +253,192 @@ describe('Query options', () => {
         }),
       );
 
-      const requestCall = fetchMock.calls('/api/post/1')[0];
-      expect(requestCall[1]).toEqual(
-        expect.objectContaining({ method: 'GET' }),
-      );
+      expect(data.post.title).toBe(post.title);
     });
 
-    it('throws if method is not GET', async () => {
+    it('can hit two endpoints!', async () => {
       expect.assertions(2);
+
+      const link = new RestLink({ endpoints: { v1: '/v1', v2: '/v2' } });
+
+      const postV1 = { id: '1', title: '1. Love apollo' };
+      const postV2 = { id: '1', titleText: '2. Love apollo' };
+      fetchMock.get('/v1/post/1', postV1);
+      fetchMock.get('/v2/post/1', postV2);
+
+      const postTitleQuery1 = gql`
+        query postTitle($id: ID!) {
+          post(id: $id) @rest(type: "Post", path: "/post/:id", endpoint: "v1") {
+            id
+            title
+          }
+        }
+      `;
+      const postTitleQuery2 = gql`
+        query postTitle($id: ID!) {
+          post(id: $id) @rest(type: "Post", path: "/post/:id", endpoint: "v2") {
+            id
+            titleText
+          }
+        }
+      `;
+
+      const data1 = await makePromise(
+        execute(link, {
+          operationName: 'postTitle1',
+          query: postTitleQuery1,
+          variables: { id: '1' },
+        }),
+      );
+      const data2 = await makePromise(
+        execute(link, {
+          operationName: 'postTitle2',
+          query: postTitleQuery2,
+          variables: { id: '1' },
+        }),
+      );
+
+      expect(data1.post.title).toBe(postV1.title);
+      expect(data2.post.titleText).toBe(postV2.titleText);
+    });
+  });
+
+  describe('Query multiple calls', () => {
+    afterEach(() => {
+      fetchMock.restore();
+    });
+
+    it('can run a query with multiple rest calls', async () => {
+      expect.assertions(2);
+      ``;
 
       const link = new RestLink({ uri: '/api' });
 
       const post = { id: '1', title: 'Love apollo' };
       fetchMock.get('/api/post/1', post);
 
-      const postTitleQuery = gql`
-        query postTitle {
-          post(id: "1") @rest(type: "Post", path: "/post/:id", method: "POST") {
+      const tags = [{ name: 'apollo' }, { name: 'graphql' }];
+      fetchMock.get('/api/tags', tags);
+
+      const postAndTags = gql`
+        query postAndTags {
+          post @rest(type: "Post", path: "/post/1") {
             id
             title
+          }
+          tags @rest(type: "[Tag]", path: "/tags") {
+            name
           }
         }
       `;
 
-      try {
+      const data = await makePromise(
+        execute(link, {
+          operationName: 'postAndTags',
+          query: postAndTags,
+        }),
+      );
+
+      expect(data.post).toBeDefined();
+      expect(data.tags).toBeDefined();
+    });
+
+    it('can run a subquery with multiple rest calls', async () => {
+      expect.assertions(2);
+      ``;
+
+      const link = new RestLink({ uri: '/api' });
+
+      const post = { id: '1', title: 'Love apollo' };
+      fetchMock.get('/api/post/1', post);
+
+      const tags = [{ name: 'apollo' }, { name: 'graphql' }];
+      fetchMock.get('/api/tags', tags);
+
+      const postAndTags = gql`
+        query postAndTags {
+          post @rest(type: "Post", path: "/post/1") {
+            id
+            title
+            tags @rest(type: "[Tag]", path: "/tags") {
+              name
+            }
+          }
+        }
+      `;
+
+      const data = await makePromise(
+        execute(link, {
+          operationName: 'postAndTags',
+          query: postAndTags,
+        }),
+      );
+
+      expect(data.post).toBeDefined();
+      expect(data.post.tags).toBeDefined();
+    });
+
+    +it('GraphQL aliases should work', async () => {
+      expect.assertions(2);
+
+      const link = new RestLink({ endpoints: { v1: '/v1', v2: '/v2' } });
+
+      const postV1 = { id: '1', title: '1. Love apollo' };
+      const postV2 = { id: '1', titleText: '2. Love apollo' };
+      fetchMock.get('/v1/post/1', postV1);
+      fetchMock.get('/v2/post/1', postV2);
+
+      const postTitleQueries = gql`
+        query postTitle($id: ID!) {
+          v1: post(id: $id)
+            @rest(type: "Post", path: "/post/:id", endpoint: "v1") {
+            id
+            title
+          }
+          v2: post(id: $id)
+            @rest(type: "Post", path: "/post/:id", endpoint: "v2") {
+            id
+            titleText
+          }
+        }
+      `;
+
+      const data = await makePromise(
+        execute(link, {
+          operationName: 'postTitle',
+          query: postTitleQueries,
+          variables: { id: '1' },
+        }),
+      );
+
+      expect(data.v1.title).toBe(postV1.title);
+      expect(data.v2.titleText).toBe(postV2.titleText);
+    });
+  });
+
+  describe('Query options', () => {
+    afterEach(() => {
+      fetchMock.restore();
+    });
+    describe('method', () => {
+      it('works for GET requests', async () => {
+        expect.assertions(1);
+
+        const link = new RestLink({ uri: '/api' });
+
+        const post = { id: '1', title: 'Love apollo' };
+        fetchMock.get('/api/post/1', post);
+
+        const postTitleQuery = gql`
+          query postTitle {
+            post(id: "1")
+              @rest(type: "Post", path: "/post/:id", method: "GET") {
+              id
+              title
+            }
+          }
+        `;
+
         await makePromise(
           execute(link, {
             operationName: 'postTitle',
@@ -466,176 +446,241 @@ describe('Query options', () => {
             variables: { id: '1' },
           }),
         );
-      } catch (error) {
-        expect(error.message).toBe(
-          'A "query" operation can only support "GET" requests but got "POST".',
+
+        const requestCall = fetchMock.calls('/api/post/1')[0];
+        expect(requestCall[1]).toEqual(
+          expect.objectContaining({ method: 'GET' }),
         );
-      }
+      });
 
-      expect(fetchMock.called('/api/post/1')).toBe(false);
+      it('works without specifying a request method', async () => {
+        expect.assertions(1);
+
+        const link = new RestLink({ uri: '/api' });
+
+        const post = { id: '1', title: 'Love apollo' };
+        fetchMock.get('/api/post/1', post);
+
+        const postTitleQuery = gql`
+          query postTitle {
+            post(id: "1") @rest(type: "Post", path: "/post/:id") {
+              id
+              title
+            }
+          }
+        `;
+
+        await makePromise(
+          execute(link, {
+            operationName: 'postTitle',
+            query: postTitleQuery,
+            variables: { id: '1' },
+          }),
+        );
+
+        const requestCall = fetchMock.calls('/api/post/1')[0];
+        expect(requestCall[1]).toEqual(
+          expect.objectContaining({ method: 'GET' }),
+        );
+      });
+
+      it('throws if method is not GET', async () => {
+        expect.assertions(2);
+
+        const link = new RestLink({ uri: '/api' });
+
+        const post = { id: '1', title: 'Love apollo' };
+        fetchMock.get('/api/post/1', post);
+
+        const postTitleQuery = gql`
+          query postTitle {
+            post(id: "1")
+              @rest(type: "Post", path: "/post/:id", method: "POST") {
+              id
+              title
+            }
+          }
+        `;
+
+        try {
+          await makePromise(
+            execute(link, {
+              operationName: 'postTitle',
+              query: postTitleQuery,
+              variables: { id: '1' },
+            }),
+          );
+        } catch (error) {
+          expect(error.message).toBe(
+            'A "query" operation can only support "GET" requests but got "POST".',
+          );
+        }
+
+        expect(fetchMock.called('/api/post/1')).toBe(false);
+      });
     });
-  });
-  describe('headers', () => {
-    it('adds headers to the request from the context', async () => {
-      expect.assertions(2);
+    describe('headers', () => {
+      it('adds headers to the request from the context', async () => {
+        expect.assertions(2);
 
-      const headersMiddleware = new ApolloLink((operation, forward) => {
-        operation.setContext({
+        const headersMiddleware = new ApolloLink((operation, forward) => {
+          operation.setContext({
+            headers: { authorization: '1234' },
+          });
+          return forward(operation).map(result => {
+            const { headers } = operation.getContext();
+            expect(headers).toBeDefined();
+            return result;
+          });
+        });
+        const link = ApolloLink.from([
+          headersMiddleware,
+          new RestLink({ uri: '/api' }),
+        ]);
+
+        const post = { id: '1', title: 'Love apollo' };
+        fetchMock.get('/api/post/1', post);
+
+        const postTitleQuery = gql`
+          query postTitle {
+            post(id: "1") @rest(type: "Post", path: "/post/:id") {
+              id
+              title
+            }
+          }
+        `;
+
+        await makePromise(
+          execute(link, {
+            operationName: 'postTitle',
+            query: postTitleQuery,
+            variables: { id: '1' },
+          }),
+        );
+
+        const requestCall = fetchMock.calls('/api/post/1')[0];
+        expect(requestCall[1]).toEqual(
+          expect.objectContaining({
+            headers: expect.objectContaining({
+              authorization: '1234',
+            }),
+          }),
+        );
+      });
+      it('adds headers to the request from the setup', async () => {
+        const link = new RestLink({
+          uri: '/api',
           headers: { authorization: '1234' },
         });
-        return forward(operation).map(result => {
-          const { headers } = operation.getContext();
-          expect(headers).toBeDefined();
-          return result;
-        });
-      });
-      const link = ApolloLink.from([
-        headersMiddleware,
-        new RestLink({ uri: '/api' }),
-      ]);
 
-      const post = { id: '1', title: 'Love apollo' };
-      fetchMock.get('/api/post/1', post);
+        const post = { id: '1', title: 'Love apollo' };
+        fetchMock.get('/api/post/1', post);
 
-      const postTitleQuery = gql`
-        query postTitle {
-          post(id: "1") @rest(type: "Post", path: "/post/:id") {
-            id
-            title
+        const postTitleQuery = gql`
+          query postTitle {
+            post(id: "1") @rest(type: "Post", path: "/post/:id") {
+              id
+              title
+            }
           }
-        }
-      `;
+        `;
 
-      await makePromise(
-        execute(link, {
-          operationName: 'postTitle',
-          query: postTitleQuery,
-          variables: { id: '1' },
-        }),
-      );
-
-      const requestCall = fetchMock.calls('/api/post/1')[0];
-      expect(requestCall[1]).toEqual(
-        expect.objectContaining({
-          headers: expect.objectContaining({
-            authorization: '1234',
+        await makePromise(
+          execute(link, {
+            operationName: 'postTitle',
+            query: postTitleQuery,
+            variables: { id: '1' },
           }),
-        }),
-      );
-    });
-    it('adds headers to the request from the setup', async () => {
-      const link = new RestLink({
-        uri: '/api',
-        headers: { authorization: '1234' },
+        );
+
+        const requestCall = fetchMock.calls('/api/post/1')[0];
+        expect(requestCall[1]).toEqual(
+          expect.objectContaining({
+            headers: expect.objectContaining({
+              authorization: '1234',
+            }),
+          }),
+        );
       });
+      it('prioritizes context headers over setup headers', async () => {
+        expect.assertions(2);
 
-      const post = { id: '1', title: 'Love apollo' };
-      fetchMock.get('/api/post/1', post);
+        const headersMiddleware = new ApolloLink((operation, forward) => {
+          operation.setContext({
+            headers: { authorization: '1234' },
+          });
+          return forward(operation).map(result => {
+            const { headers } = operation.getContext();
+            expect(headers).toBeDefined();
+            return result;
+          });
+        });
+        const link = ApolloLink.from([
+          headersMiddleware,
+          new RestLink({ uri: '/api', headers: { authorization: 'no user' } }),
+        ]);
 
-      const postTitleQuery = gql`
-        query postTitle {
-          post(id: "1") @rest(type: "Post", path: "/post/:id") {
-            id
-            title
+        const post = { id: '1', title: 'Love apollo' };
+        fetchMock.get('/api/post/1', post);
+
+        const postTitleQuery = gql`
+          query postTitle {
+            post(id: "1") @rest(type: "Post", path: "/post/:id") {
+              id
+              title
+            }
           }
-        }
-      `;
+        `;
 
-      await makePromise(
-        execute(link, {
-          operationName: 'postTitle',
-          query: postTitleQuery,
-          variables: { id: '1' },
-        }),
-      );
-
-      const requestCall = fetchMock.calls('/api/post/1')[0];
-      expect(requestCall[1]).toEqual(
-        expect.objectContaining({
-          headers: expect.objectContaining({
-            authorization: '1234',
+        await makePromise(
+          execute(link, {
+            operationName: 'postTitle',
+            query: postTitleQuery,
+            variables: { id: '1' },
           }),
-        }),
-      );
-    });
-    it('prioritizes context headers over setup headers', async () => {
-      expect.assertions(2);
+        );
 
-      const headersMiddleware = new ApolloLink((operation, forward) => {
-        operation.setContext({
-          headers: { authorization: '1234' },
-        });
-        return forward(operation).map(result => {
-          const { headers } = operation.getContext();
-          expect(headers).toBeDefined();
-          return result;
-        });
+        const requestCall = fetchMock.calls('/api/post/1')[0];
+        expect(requestCall[1]).toEqual(
+          expect.objectContaining({
+            headers: expect.objectContaining({
+              authorization: '1234',
+            }),
+          }),
+        );
       });
-      const link = ApolloLink.from([
-        headersMiddleware,
-        new RestLink({ uri: '/api', headers: { authorization: 'no user' } }),
-      ]);
-
-      const post = { id: '1', title: 'Love apollo' };
-      fetchMock.get('/api/post/1', post);
-
-      const postTitleQuery = gql`
-        query postTitle {
-          post(id: "1") @rest(type: "Post", path: "/post/:id") {
-            id
-            title
-          }
-        }
-      `;
-
-      await makePromise(
-        execute(link, {
-          operationName: 'postTitle',
-          query: postTitleQuery,
-          variables: { id: '1' },
-        }),
-      );
-
-      const requestCall = fetchMock.calls('/api/post/1')[0];
-      expect(requestCall[1]).toEqual(
-        expect.objectContaining({
-          headers: expect.objectContaining({
-            authorization: '1234',
-          }),
-        }),
-      );
     });
   });
-});
 
-describe('validateRequestMethodForOperationType', () => {
-  const createRequestParams = (params = {}) => ({
-    name: 'post',
-    filteredKeys: [],
-    endpoint: `/api/post/1`,
-    method: 'POST',
-    ...params,
-  });
-  describe('for operation type "mutation"', () => {
-    it('throws because it is not supported yet', () => {
-      expect.assertions(1);
-      expect(() =>
-        validateRequestMethodForOperationType(
-          [createRequestParams()],
-          'mutation',
-        ),
-      ).toThrowError('A "mutation" operation is not supported yet.');
+  describe('validateRequestMethodForOperationType', () => {
+    const createRequestParams = (params = {}) => ({
+      name: 'post',
+      filteredKeys: [],
+      endpoint: `/api/post/1`,
+      method: 'POST',
+      ...params,
     });
-  });
-  describe('for operation type "subscription"', () => {
-    it('throws because it is not supported yet', () => {
-      expect.assertions(1);
-      expect(() =>
-        validateRequestMethodForOperationType(
-          [createRequestParams()],
-          'subscription',
-        ),
-      ).toThrowError('A "subscription" operation is not supported yet.');
+    describe('for operation type "mutation"', () => {
+      it('throws because it is not supported yet', () => {
+        expect.assertions(1);
+        expect(() =>
+          validateRequestMethodForOperationType(
+            [createRequestParams()],
+            'mutation',
+          ),
+        ).toThrowError('A "mutation" operation is not supported yet.');
+      });
+    });
+    describe('for operation type "subscription"', () => {
+      it('throws because it is not supported yet', () => {
+        expect.assertions(1);
+        expect(() =>
+          validateRequestMethodForOperationType(
+            [createRequestParams()],
+            'subscription',
+          ),
+        ).toThrowError('A "subscription" operation is not supported yet.');
+      });
     });
   });
 });

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -17,6 +17,7 @@ export type RestLinkOptions = {
   headers?: {
     [headerKey: string]: string;
   };
+  fieldNameNormalizer?: Function;
 };
 
 const addTypeNameToResult = (result, __typename) => {
@@ -38,6 +39,22 @@ const replaceParam = (endpoint, name, value) => {
     return endpoint;
   }
   return endpoint.replace(`:${name}`, value);
+};
+
+const convertObjectKeys = (object, converter) => {
+  return Object.keys(object)
+    .filter(e => e !== '__typename')
+    .reduce((acc, val) => {
+      let value = object[val];
+      if (typeof value === 'object') {
+        value = convertObjectKeys(value, converter);
+      }
+      if (Array.isArray(value)) {
+        value = value.map(e => convertObjectKeys(e, converter));
+      }
+      acc[converter(val)] = value;
+      return acc;
+    }, {});
 };
 
 export const validateRequestMethodForOperationType = (
@@ -67,9 +84,9 @@ export const validateRequestMethodForOperationType = (
 };
 
 const resolver = async (fieldName, root, args, context, info) => {
-  const { directives, isLeaf } = info;
+  const { directives, isLeaf, resultKey } = info;
   if (isLeaf) {
-    return root[fieldName];
+    return root[resultKey];
   }
   const { endpoints, headers } = context;
   const { path, endpoint } = directives.rest;
@@ -108,7 +125,13 @@ const DEFAULT_ENDPOINT_KEY = '';
 export class RestLink extends ApolloLink {
   private endpoints: { [endpointKey: string]: string };
   private headers: { [headerKey: string]: string };
-  constructor({ uri, endpoints, headers }: RestLinkOptions) {
+  private fieldNameNormalizer: Function;
+  constructor({
+    uri,
+    endpoints,
+    headers,
+    fieldNameNormalizer,
+  }: RestLinkOptions) {
     super();
     const fallback = {};
     fallback[DEFAULT_ENDPOINT_KEY] = uri || '';
@@ -135,6 +158,7 @@ export class RestLink extends ApolloLink {
       );
     }
 
+    this.fieldNameNormalizer = fieldNameNormalizer || null;
     this.headers = headers || {};
   }
 
@@ -155,6 +179,14 @@ export class RestLink extends ApolloLink {
 
     const queryWithTypename = addTypenameToDocument(query);
 
+    let resolverOptions = {};
+    if (this.fieldNameNormalizer) {
+      resolverOptions = {
+        resultMapper: resultFields =>
+          convertObjectKeys(resultFields, this.fieldNameNormalizer),
+      };
+    }
+
     return new Observable(observer => {
       try {
         const result = graphql(
@@ -163,6 +195,7 @@ export class RestLink extends ApolloLink {
           null,
           { headers, endpoints: this.endpoints },
           variables,
+          resolverOptions,
         );
         observer.next(result);
         observer.complete();


### PR DESCRIPTION
This PR should be accepted after https://github.com/apollographql/apollo-link-rest/pull/12.

Add a `fieldNameNormalizer` param to the link that will apply a converter to each keys of the resulting object.

I considered it as a first version as I do not like the `convertObjectKeys` function.

If no one has a better idea, then I will write tests for this function in a separate file. 