### PR TITLE
Add support for credentials

### DIFF
--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -83,6 +83,41 @@ describe('Configuration', () => {
       expect(data.post.tags[0].name).toBeDefined();
     });
   });
+
+  describe('Credentials', () => {
+    afterEach(() => {
+      fetchMock.restore();
+    });
+
+    it('adds credentials to the request from the setup', async () => {
+      expect.assertions(1);
+      const link = new RestLink({
+        uri: '/api',
+        credentials: 'my-credentials',
+      });
+
+      const post = { id: '1', Title: 'Love apollo' };
+      fetchMock.get('/api/post/1', post);
+
+      const query = gql`
+        query post {
+          post @rest(type: "Post", path: "/post/1") {
+            id
+          }
+        }
+      `;
+
+      const data = await makePromise(
+        execute(link, {
+          operationName: 'postTitle',
+          query,
+        }),
+      );
+
+      const credentials = fetchMock.lastCall()[1].credentials;
+      expect(credentials).toBe('my-credentials');
+    });
+  });
 });
 
 describe('Query single call', () => {

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -174,7 +174,11 @@ export class RestLink extends ApolloLink {
     operation: Operation,
     forward?: NextLink,
   ): Observable<FetchResult> | null {
-    const { query, variables } = operation;
+    const { query, variables, getContext } = operation;
+    const {
+      headers: contextHeaders = {},
+      credentials: contextCredentials,
+    } = getContext();
     const isRestQuery = hasDirectives(['rest'], operation.query);
     if (!isRestQuery) {
       return forward(operation);
@@ -182,10 +186,10 @@ export class RestLink extends ApolloLink {
 
     const headers = {
       ...this.headers,
-      ...(operation.getContext().headers || {}),
+      ...contextHeaders,
     };
 
-    const credentials = this.credentials;
+    const credentials = this.credentials || contextCredentials;
 
     const queryWithTypename = addTypenameToDocument(query);
 

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -189,7 +189,7 @@ export class RestLink extends ApolloLink {
       ...contextHeaders,
     };
 
-    const credentials = this.credentials || contextCredentials;
+    const credentials = contextCredentials || this.credentials;
 
     const queryWithTypename = addTypenameToDocument(query);
 


### PR DESCRIPTION
Add support for `credentials` (#3). The `credentials` can be passed by operation context or `RestLink` options, prioritizing context. This logic is basically identical to [`apollo-link-http`](https://github.com/apollographql/apollo-link/blob/master/packages/apollo-link-http).