### PR TITLE
Export directive

### DIFF
--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -765,37 +765,74 @@ describe('validateRequestMethodForOperationType', () => {
         ),
       ).toThrowError('A "mutation" operation is not supported yet.');
     });
-    describe('for operation type "subscription"', () => {
-      it('throws because it is not supported yet', () => {
-        expect.assertions(1);
-        expect(() =>
-          validateRequestMethodForOperationType(
-            [createRequestParams()],
-            'subscription',
-          ),
-        ).toThrowError('A "subscription" operation is not supported yet.');
-      });
+  });
+  describe('for operation type "subscription"', () => {
+    it('throws because it is not supported yet', () => {
+      expect.assertions(1);
+      expect(() =>
+        validateRequestMethodForOperationType(
+          [createRequestParams()],
+          'subscription',
+        ),
+      ).toThrowError('A "subscription" operation is not supported yet.');
     });
-    describe('for operation type "mutation"', () => {
-      it('throws because it is not supported yet', () => {
-        expect.assertions(1);
-        expect(() =>
-          validateRequestMethodForOperationType('POST', 'mutation'),
-        ).toThrowError('A "mutation" operation is not supported yet.');
-      });
+  });
+  describe('for operation type "mutation"', () => {
+    it('throws because it is not supported yet', () => {
+      expect.assertions(1);
+      expect(() =>
+        validateRequestMethodForOperationType('POST', 'mutation'),
+      ).toThrowError('A "mutation" operation is not supported yet.');
     });
-    describe('for operation type "subscription"', () => {
-      it('throws because it is not supported yet', () => {
-        expect.assertions(1);
-        expect(() =>
-          validateRequestMethodForOperationType('POST', 'subscription'),
-        ).toThrowError('A "subscription" operation is not supported yet.');
-      });
+  });
+  describe('for operation type "subscription"', () => {
+    it('throws because it is not supported yet', () => {
+      expect.assertions(1);
+      expect(() =>
+        validateRequestMethodForOperationType('POST', 'subscription'),
+      ).toThrowError('A "subscription" operation is not supported yet.');
     });
   });
 });
 
-describe('export', () => {
+describe('export directive', () => {
+  afterEach(() => {
+    fetchMock.restore();
+  });
+  it('should throw an error if export is missing', async () => {
+    expect.assertions(1);
+
+    const link = new RestLink({ uri: '/api' });
+
+    const post = { id: '1', title: 'Love apollo', tagId: 6 };
+    fetchMock.get('/api/post/1', post);
+
+    const postTagWithoutExport = gql`
+      query postTitle {
+        post(id: "1") @rest(type: "Post", path: "/post/:id") {
+          tagId
+          title
+          tag @rest(type: "Tag", path: "/tag/:tagId") {
+            name
+          }
+        }
+      }
+    `;
+
+    try {
+      await makePromise(
+        execute(link, {
+          operationName: 'postTitle',
+          query: postTagWithoutExport,
+          variables: { id: '1' },
+        }),
+      );
+    } catch (e) {
+      expect(e.message).toBe(
+        'Missing params to run query, specify it in the query params or use an export directive',
+      );
+    }
+  });
   it('can use a variable from export', async () => {
     expect.assertions(1);
 
@@ -827,5 +864,45 @@ describe('export', () => {
     );
 
     expect(data.post.tag).toEqual({ ...tag, __typename: 'Tag' });
+  });
+
+  it('can use two variables from export', async () => {
+    expect.assertions(2);
+
+    const link = new RestLink({ uri: '/api' });
+
+    const post = { id: '1', title: 'Love apollo', tagId: 6, postAuthor: 10 };
+    fetchMock.get('/api/post/1', post);
+    const tag = { name: 'apollo' };
+    fetchMock.get('/api/tag/6', tag);
+    const author = { name: 'Sashko' };
+    fetchMock.get('/api/users/10', author);
+
+    const postTagExport = gql`
+      query postTitle {
+        post(id: "1") @rest(type: "Post", path: "/post/:id") {
+          tagId @export(as: "tagId")
+          postAuthor @export(as: "authorId")
+          title
+          tag @rest(type: "Tag", path: "/tag/:tagId") {
+            name
+          }
+          author @rest(type: "User", path: "/users/:authorId") {
+            name
+          }
+        }
+      }
+    `;
+
+    const data = await makePromise(
+      execute(link, {
+        operationName: 'postTitle',
+        query: postTagExport,
+        variables: { id: '1' },
+      }),
+    );
+
+    expect(data.post.tag).toEqual({ ...tag, __typename: 'Tag' });
+    expect(data.post.author).toEqual({ ...author, __typename: 'User' });
   });
 });

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -107,6 +107,11 @@ const resolver = async (fieldName, root, args, context, info) => {
       (acc, e) => replaceParam(acc, e, argsWithExport[e]),
       path,
     );
+    if (pathWithParams.includes(':')) {
+      throw new Error(
+        'Missing params to run query, specify it in the query params or use an export directive',
+      );
+    }
     let { method, type } = directives.rest;
     if (!method) {
       method = 'GET';
@@ -166,11 +171,11 @@ export class RestLink extends ApolloLink {
       this.endpoints[DEFAULT_ENDPOINT_KEY] == uri;
     }
 
-    // if (this.endpoints[DEFAULT_ENDPOINT_KEY] == null) {
-    //   console.warn(
-    //     'RestLink configured without a default URI. All @rest(…) directives must provide an endpoint key!',
-    //   );
-    // }
+    if (this.endpoints[DEFAULT_ENDPOINT_KEY] == null) {
+      console.warn(
+        'RestLink configured without a default URI. All @rest(…) directives must provide an endpoint key!',
+      );
+    }
 
     this.fieldNameNormalizer = fieldNameNormalizer || null;
     this.headers = headers || {};


### PR DESCRIPTION
This PR allow the use of an export directive inside a query so that we can use the result as a variable of a previous query.

For example : 

```graphql
query postTitle {
        post(id: "1") @rest(type: "Post", path: "/post/:id") {
          tagId @export(as: "tagId")
          title
          tag @rest(type: "Tag", path: "/tag/:tagId") {
            name
          }
        }
      }
```