### PR TITLE
Custom fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "apollo-link": "^1.0.3",
+    "cross-fetch": "^1.1.1",
     "graphql-anywhere": "^4.1.0-alpha.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   },
   "dependencies": {
     "apollo-link": "^1.0.3",
-    "cross-fetch": "^1.1.1",
     "graphql-anywhere": "^4.1.0-alpha.0"
   },
   "peerDependencies": {

--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -765,6 +765,40 @@ describe('validateRequestMethodForOperationType', () => {
         ),
       ).toThrowError('A "mutation" operation is not supported yet.');
     });
+    describe('export', () => {
+      it('can use a variable from export', async () => {
+        expect.assertions(1);
+
+        const link = new RestLink({ uri: '/api' });
+
+        const post = { id: '1', title: 'Love apollo', tagId: 6 };
+        fetchMock.get('/api/post/1', post);
+        const tag = { name: 'apollo' };
+        fetchMock.get('/api/tag/6', tag);
+
+        const postTagExport = gql`
+          query postTitle {
+            post(id: "1") @rest(type: "Post", path: "/post/:id") {
+              tagId @export(as: "tagId")
+              title
+              tag @rest(type: "Tag", path: "/tag/:tagId") {
+                name
+              }
+            }
+          }
+        `;
+
+        const data = await makePromise(
+          execute(link, {
+            operationName: 'postTitle',
+            query: postTagExport,
+            variables: { id: '1' },
+          }),
+        );
+
+        expect(data.post.tag).toEqual({ ...tag, __typename: 'Tag' });
+      });
+    });
   });
   describe('for operation type "subscription"', () => {
     it('throws because it is not supported yet', () => {

--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -91,6 +91,41 @@ describe('Configuration', () => {
       expect(data.post.tags[0].name).toBeDefined();
     });
   });
+
+  describe('Custom fetch', () => {
+    afterEach(() => {
+      fetchMock.restore();
+    });
+    it('should apply customFetch if specified', async () => {
+      expect.assertions(1);
+
+      const link = new RestLink({
+        uri: '/api',
+        customFetch: (uri, options) =>
+          new Promise((resolve, reject) => {
+            const body = JSON.stringify({ title: 'custom' });
+            resolve(new Response(body));
+          }),
+      });
+
+      const postTitle = gql`
+        query postTitle {
+          post @rest(type: "Post", path: "/post/1") {
+            title
+          }
+        }
+      `;
+
+      const data = await makePromise(
+        execute(link, {
+          operationName: 'postTitle',
+          query: postTitle,
+        }),
+      );
+
+      expect(data.post.title).toBe('custom');
+    });
+  });
 });
 
 describe('Query single call', () => {

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -107,6 +107,11 @@ const resolver = async (fieldName, root, args, context, info) => {
       (acc, e) => replaceParam(acc, e, argsWithExport[e]),
       path,
     );
+    if (pathWithParams.includes(':')) {
+      throw new Error(
+        'Missing params to run query, specify it in the query params or use an export directive',
+      );
+    }
     let { method, type } = directives.rest;
     if (!method) {
       method = 'GET';
@@ -166,11 +171,11 @@ export class RestLink extends ApolloLink {
       this.endpoints[DEFAULT_ENDPOINT_KEY] == uri;
     }
 
-    // if (this.endpoints[DEFAULT_ENDPOINT_KEY] == null) {
-    //   console.warn(
-    //     'RestLink configured without a default URI. All @rest(…) directives must provide an endpoint key!',
-    //   );
-    // }
+    if (this.endpoints[DEFAULT_ENDPOINT_KEY] == null) {
+      console.warn(
+        'RestLink configured without a default URI. All @rest(…) directives must provide an endpoint key!',
+      );
+    }
 
     this.fieldNameNormalizer = fieldNameNormalizer || null;
     this.headers = headers || {};
@@ -214,7 +219,7 @@ export class RestLink extends ApolloLink {
           resolver,
           queryWithTypename,
           null,
-          { headers, endpoints: this.endpoints, export: exportVariables },
+          { headers, credentials, endpoints: this.endpoints, export: exportVariables },
           variables,
           resolverOptions,
         );

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -84,22 +84,29 @@ export const validateRequestMethodForOperationType = (
   }
 };
 
+let exportVariables = {};
+
 const resolver = async (fieldName, root, args, context, info) => {
   const { directives, isLeaf, resultKey } = info;
+  if (root === null) {
+    exportVariables = {};
+  }
   if (isLeaf) {
-    return root[resultKey];
+    const leafValue = root[resultKey];
+    if (directives && directives.export) {
+      exportVariables[directives.export.as] = leafValue;
+    }
+    return leafValue;
   }
   const { credentials, endpoints, headers } = context;
   const { path, endpoint } = directives.rest;
   const uri = getURIFromEndpoints(endpoints, endpoint);
   try {
-    let pathWithParams = path;
-    if (args) {
-      pathWithParams = Object.keys(args).reduce(
-        (acc, e) => replaceParam(acc, e, args[e]),
-        path,
-      );
-    }
+    const argsWithExport = { ...args, ...exportVariables };
+    let pathWithParams = Object.keys(argsWithExport).reduce(
+      (acc, e) => replaceParam(acc, e, argsWithExport[e]),
+      path,
+    );
     let { method, type } = directives.rest;
     if (!method) {
       method = 'GET';
@@ -159,11 +166,11 @@ export class RestLink extends ApolloLink {
       this.endpoints[DEFAULT_ENDPOINT_KEY] == uri;
     }
 
-    if (this.endpoints[DEFAULT_ENDPOINT_KEY] == null) {
-      console.warn(
-        'RestLink configured without a default URI. All @rest(…) directives must provide an endpoint key!',
-      );
-    }
+    // if (this.endpoints[DEFAULT_ENDPOINT_KEY] == null) {
+    //   console.warn(
+    //     'RestLink configured without a default URI. All @rest(…) directives must provide an endpoint key!',
+    //   );
+    // }
 
     this.fieldNameNormalizer = fieldNameNormalizer || null;
     this.headers = headers || {};
@@ -207,7 +214,7 @@ export class RestLink extends ApolloLink {
           resolver,
           queryWithTypename,
           null,
-          { headers, endpoints: this.endpoints, credentials },
+          { headers, endpoints: this.endpoints, export: exportVariables },
           variables,
           resolverOptions,
         );


### PR DESCRIPTION
This PR adds the ability to pass a customFetch as parameters.

For example : 

```js
const link = new RestLink({
        uri: '/api',
        customFetch: (uri, options) =>
          new Promise((resolve, reject) => {
            const body = JSON.stringify({ title: 'custom' });
            resolve(new Response(body));
          }),
      });
```