### PR TITLE
Apollo client test

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "@types/graphql": "0.11.5",
     "@types/jest": "21.1.5",
     "@types/node": "^8.0.53",
+    "apollo-cache-inmemory": "^1.1.4",
+    "apollo-client": "^2.0.4",
     "apollo-link-http": "1.2.0",
     "browserify": "14.5.0",
     "bundlesize": "0.15.3",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "apollo-link": "^1.0.3",
+    "cross-fetch": "^1.1.1",
     "graphql-anywhere": "^4.1.0-alpha.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   },
   "dependencies": {
     "apollo-link": "^1.0.3",
-    "cross-fetch": "^1.1.1",
     "graphql-anywhere": "^4.1.0-alpha.0"
   },
   "peerDependencies": {

--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -91,6 +91,41 @@ describe('Configuration', () => {
       expect(data.post.tags[0].name).toBeDefined();
     });
   });
+
+  describe('Custom fetch', () => {
+    afterEach(() => {
+      fetchMock.restore();
+    });
+    it('should apply customFetch if specified', async () => {
+      expect.assertions(1);
+
+      const link = new RestLink({
+        uri: '/api',
+        customFetch: (uri, options) =>
+          new Promise((resolve, reject) => {
+            const body = JSON.stringify({ title: 'custom' });
+            resolve(new Response(body));
+          }),
+      });
+
+      const postTitle = gql`
+        query postTitle {
+          post @rest(type: "Post", path: "/post/1") {
+            title
+          }
+        }
+      `;
+
+      const data = await makePromise(
+        execute(link, {
+          operationName: 'postTitle',
+          query: postTitle,
+        }),
+      );
+
+      expect(data.post.title).toBe('custom');
+    });
+  });
 });
 
 describe('Query single call', () => {

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -18,6 +18,7 @@ export type RestLinkOptions = {
     [headerKey: string]: string;
   };
   fieldNameNormalizer?: Function;
+  customFetch?: Function;
   credentials?: string;
 };
 
@@ -98,7 +99,7 @@ const resolver = async (fieldName, root, args, context, info) => {
     }
     return leafValue;
   }
-  const { credentials, endpoints, headers } = context;
+  const { credentials, endpoints, headers, customFetch } = context;
   const { path, endpoint } = directives.rest;
   const uri = getURIFromEndpoints(endpoints, endpoint);
   try {
@@ -117,7 +118,7 @@ const resolver = async (fieldName, root, args, context, info) => {
       method = 'GET';
     }
     validateRequestMethodForOperationType(method, 'query');
-    return await fetch(`${uri}${pathWithParams}`, {
+    return await (customFetch || fetch)(`${uri}${pathWithParams}`, {
       credentials,
       method,
       headers,
@@ -143,12 +144,14 @@ export class RestLink extends ApolloLink {
   private endpoints: { [endpointKey: string]: string };
   private headers: { [headerKey: string]: string };
   private fieldNameNormalizer: Function;
+  private customFetch: Function;
   private credentials: string;
   constructor({
     uri,
     endpoints,
     headers,
     fieldNameNormalizer,
+    customFetch,
     credentials,
   }: RestLinkOptions) {
     super();
@@ -180,6 +183,7 @@ export class RestLink extends ApolloLink {
     this.fieldNameNormalizer = fieldNameNormalizer || null;
     this.headers = headers || {};
     this.credentials = credentials || null;
+    this.customFetch = customFetch;
   }
 
   public request(
@@ -224,6 +228,7 @@ export class RestLink extends ApolloLink {
             endpoints: this.endpoints,
             export: exportVariables,
             credentials,
+            customFetch: this.customFetch,
           },
           variables,
           resolverOptions,

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -218,26 +218,27 @@ export class RestLink extends ApolloLink {
     }
 
     return new Observable(observer => {
-      try {
-        const result = graphql(
-          resolver,
-          queryWithTypename,
-          null,
-          {
-            headers,
-            endpoints: this.endpoints,
-            export: exportVariables,
-            credentials,
-            customFetch: this.customFetch,
-          },
-          variables,
-          resolverOptions,
-        );
-        observer.next(result);
-        observer.complete();
-      } catch (err) {
-        observer.error.bind(observer);
-      }
+      graphql(
+        resolver,
+        queryWithTypename,
+        null,
+        {
+          headers,
+          endpoints: this.endpoints,
+          export: exportVariables,
+          credentials,
+          customFetch: this.customFetch,
+        },
+        variables,
+        resolverOptions,
+      )
+        .then(data => {
+          observer.next({ data });
+          observer.complete();
+        })
+        .catch(err => {
+          observer.error(err);
+        });
     });
   }
 }


### PR DESCRIPTION
I just add a test that uses apollo-client to be sure that our link was working where it is planned to be used.

This took me ages to realize that our response needed to be wrapped into an object with a data key to have the in-memory-cache to accept it.

Things are looking better and better