### PR TITLE
Update Typings & Require Valid Types for CI Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ script:
     # make sure files don't get too large
   - npm run filesize
 
+    # make sure there are no type errors
+  - npm run check-types
+
 # Allow Travis tests to run in containers.
 sudo: false
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "prepublishOnly": "npm run clean && npm run build",
     "test": "jest",
     "coverage": "npm run lint && jest --coverage",
-    "watch": "tsc -w -p ."
+    "watch": "tsc -w -p .",
+    "check-types":
+      "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.tests.json"
   },
   "dependencies": {
     "apollo-link": "^1.0.3",

--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -960,7 +960,7 @@ describe('Apollo client integration', () => {
       link,
     });
 
-    const { data } = await client.query({
+    const { data }: { data: any } = await client.query({
       query: postTagExport,
     });
 

--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -14,19 +14,21 @@ const sampleQuery = gql`
   }
 `;
 
+type Result = { [index: string]: any };
+
 describe('Configuration', () => {
   describe('Errors', () => {
     it('throws without any config', () => {
       expect.assertions(3);
 
       expect(() => {
-        new RestLink();
+        new RestLink(undefined);
       }).toThrow();
       expect(() => {
-        new RestLink({});
+        new RestLink({} as any);
       }).toThrow();
       expect(() => {
-        new RestLink({ bogus: '' });
+        new RestLink({ bogus: '' } as any);
       }).toThrow();
     });
 
@@ -80,7 +82,7 @@ describe('Configuration', () => {
         }
       `;
 
-      const data = await makePromise(
+      const data = await makePromise<Result>(
         execute(link, {
           operationName: 'postTitle',
           query: postAndTags,
@@ -114,7 +116,7 @@ describe('Query single call', () => {
       }
     `;
 
-    const data = await makePromise(
+    const data = await makePromise<Result>(
       execute(link, {
         operationName: 'postTitle',
         query: postTitleQuery,
@@ -140,7 +142,7 @@ describe('Query single call', () => {
       }
     `;
 
-    const data = await makePromise(
+    const data = await makePromise<Result>(
       execute(link, {
         operationName: 'postTitle',
         query: postTitleQuery,
@@ -166,7 +168,7 @@ describe('Query single call', () => {
       }
     `;
 
-    const data = await makePromise(
+    const data = await makePromise<Result>(
       execute(link, {
         operationName: 'tags',
         query: tagsQuery,
@@ -201,7 +203,7 @@ describe('Query single call', () => {
       }
     `;
 
-    const data = await makePromise(
+    const data = await makePromise<Result>(
       execute(link, {
         operationName: 'postWithContent',
         query: postTitleQuery,
@@ -227,7 +229,7 @@ describe('Query single call', () => {
       }
     `;
 
-    const data = await makePromise(
+    const data = await makePromise<Result>(
       execute(link, {
         operationName: 'postTitle',
         query: postTitleQuery,
@@ -254,7 +256,7 @@ describe('Query single call', () => {
       }
     `;
 
-    const data = await makePromise(
+    const data = await makePromise<Result>(
       execute(link, {
         operationName: 'postTitle',
         query: postTitleQuery,
@@ -292,14 +294,14 @@ describe('Query single call', () => {
       }
     `;
 
-    const data1 = await makePromise(
+    const data1 = await makePromise<Result>(
       execute(link, {
         operationName: 'postTitle1',
         query: postTitleQuery1,
         variables: { id: '1' },
       }),
     );
-    const data2 = await makePromise(
+    const data2 = await makePromise<Result>(
       execute(link, {
         operationName: 'postTitle2',
         query: postTitleQuery2,
@@ -341,7 +343,7 @@ describe('Query multiple calls', () => {
       }
     `;
 
-    const data = await makePromise(
+    const data = await makePromise<Result>(
       execute(link, {
         operationName: 'postAndTags',
         query: postAndTags,
@@ -376,7 +378,7 @@ describe('Query multiple calls', () => {
       }
     `;
 
-    const data = await makePromise(
+    const data = await makePromise<Result>(
       execute(link, {
         operationName: 'postAndTags',
         query: postAndTags,
@@ -412,7 +414,7 @@ describe('Query multiple calls', () => {
       }
     `;
 
-    const data = await makePromise(
+    const data = await makePromise<Result>(
       execute(link, {
         operationName: 'postTitle',
         query: postTitleQueries,
@@ -440,7 +442,7 @@ describe('Query options', () => {
       const post = { id: '1', Title: 'Love apollo' };
       fetchMock.get('/api/post/1', post);
 
-      await makePromise(
+      await makePromise<Result>(
         execute(link, {
           operationName: 'post',
           query: sampleQuery,
@@ -473,7 +475,7 @@ describe('Query options', () => {
       const post = { id: '1', title: 'Love apollo' };
       fetchMock.get('/api/post/1', post);
 
-      await makePromise(
+      await makePromise<Result>(
         execute(link, {
           operationName: 'post',
           query: sampleQuery,
@@ -506,7 +508,7 @@ describe('Query options', () => {
       const post = { id: '1', title: 'Love apollo' };
       fetchMock.get('/api/post/1', post);
 
-      await makePromise(
+      await makePromise<Result>(
         execute(link, {
           operationName: 'post',
           query: sampleQuery,
@@ -535,7 +537,7 @@ describe('Query options', () => {
         }
       `;
 
-      await makePromise(
+      await makePromise<Result>(
         execute(link, {
           operationName: 'postTitle',
           query: postTitleQuery,
@@ -566,7 +568,7 @@ describe('Query options', () => {
         }
       `;
 
-      await makePromise(
+      await makePromise<Result>(
         execute(link, {
           operationName: 'postTitle',
           query: postTitleQuery,
@@ -598,7 +600,7 @@ describe('Query options', () => {
       `;
 
       try {
-        await makePromise(
+        await makePromise<Result>(
           execute(link, {
             operationName: 'postTitle',
             query: postTitleQuery,
@@ -645,7 +647,7 @@ describe('Query options', () => {
         }
       `;
 
-      await makePromise(
+      await makePromise<Result>(
         execute(link, {
           operationName: 'postTitle',
           query: postTitleQuery,
@@ -680,7 +682,7 @@ describe('Query options', () => {
         }
       `;
 
-      await makePromise(
+      await makePromise<Result>(
         execute(link, {
           operationName: 'postTitle',
           query: postTitleQuery,
@@ -727,7 +729,7 @@ describe('Query options', () => {
         }
       `;
 
-      await makePromise(
+      await makePromise<Result>(
         execute(link, {
           operationName: 'postTitle',
           query: postTitleQuery,
@@ -748,21 +750,11 @@ describe('Query options', () => {
 });
 
 describe('validateRequestMethodForOperationType', () => {
-  const createRequestParams = (params = {}) => ({
-    name: 'post',
-    filteredKeys: [],
-    endpoint: `/api/post/1`,
-    method: 'POST',
-    ...params,
-  });
   describe('for operation type "mutation"', () => {
     it('throws because it is not supported yet', () => {
       expect.assertions(1);
       expect(() =>
-        validateRequestMethodForOperationType(
-          [createRequestParams()],
-          'mutation',
-        ),
+        validateRequestMethodForOperationType('GET', 'mutation'),
       ).toThrowError('A "mutation" operation is not supported yet.');
     });
   });
@@ -770,10 +762,7 @@ describe('validateRequestMethodForOperationType', () => {
     it('throws because it is not supported yet', () => {
       expect.assertions(1);
       expect(() =>
-        validateRequestMethodForOperationType(
-          [createRequestParams()],
-          'subscription',
-        ),
+        validateRequestMethodForOperationType('GET', 'subscription'),
       ).toThrowError('A "subscription" operation is not supported yet.');
     });
   });

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -22,7 +22,9 @@ export namespace RestLink {
     [headerKey: string]: Header;
   }
 
-  export type FieldNameNormalizer = (fieldName: string) => string;
+  export interface FieldNameNormalizer {
+    (fieldName: string): string;
+  }
 
   export type Credentials = string;
 

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -165,8 +165,6 @@ const DEFAULT_ENDPOINT_KEY = '';
 
 /**
  * RestLink is an apollo-link for communicating with REST services using GraphQL on the client-side
- * - @param: uri: default URI, optional if endpoints provides a default.
- * - @param: endpoints: optional map of potential API endpoints this RestLink will hit.
  */
 export class RestLink extends ApolloLink {
   private endpoints: RestLink.Endpoints;

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -12,12 +12,14 @@ import { graphql } from 'graphql-anywhere/lib/async';
 export namespace RestLink {
   export type URI = string;
 
+  export type Endpoint = string;
   export interface Endpoints {
-    [endpointKey: string]: string;
+    [endpointKey: string]: Endpoint;
   }
 
+  export type Header = string;
   export interface Headers {
-    [headerKey: string]: string;
+    [headerKey: string]: Header;
   }
 
   export type FieldNameNormalizer = (fieldName: string) => string;
@@ -54,14 +56,20 @@ export namespace RestLink {
   };
 }
 
-const addTypeNameToResult = (result, __typename) => {
+const addTypeNameToResult = (
+  result: any[] | object,
+  __typename: string,
+): any[] | object => {
   if (Array.isArray(result)) {
     return result.map(e => ({ ...e, __typename }));
   }
   return { ...result, __typename };
 };
 
-const getURIFromEndpoints = (endpoints, endpoint) => {
+const getURIFromEndpoints = (
+  endpoints: RestLink.Endpoints,
+  endpoint: RestLink.Endpoint,
+): RestLink.URI => {
   return (
     endpoints[endpoint || DEFAULT_ENDPOINT_KEY] ||
     endpoints[DEFAULT_ENDPOINT_KEY]
@@ -165,6 +173,7 @@ export class RestLink extends ApolloLink {
   private headers: RestLink.Headers;
   private fieldNameNormalizer: RestLink.FieldNameNormalizer;
   private credentials: RestLink.Credentials;
+
   constructor({
     uri,
     endpoints,

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig",
+  "include": ["src/**/__tests__/*.ts"],
+  "exclude": []
+}


### PR DESCRIPTION
#### This PR refactors the typings for the `RestLink` implementation and the specs:

- Update the `RestLink` types and the `Options` following a similar pattern to [`apollo-link-http`](https://github.com/apollographql/apollo-link/tree/master/packages/apollo-link-http).
- Add a `script` to `package.json` to easily `check-types` (TypeScript compilation without emitting)
- Add `npm run check-types` to the `.travis.yml` config to require valid types to pass the build
- Start adding types to the helper functions (more to come)
- Add a `tsconfig.tests.json` that extends the base `tsconfig.json`. (Note: open to alternatives, this was the only approach I was able to find that enforced valid types in the specs without including the tests in the bundle when running `yarn build`)

#### Updated CI Ouput:

![image](https://user-images.githubusercontent.com/5247455/33810785-f23d00be-ddbd-11e7-987c-7038de8c4074.png)