### PR TITLE
Add additional types

### DIFF
--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -115,10 +115,6 @@ export const validateRequestMethodForOperationType = (
   method: string,
   operationType: OperationTypeNode,
 ) => {
-  /**
-   * NOTE: possible improvements
-   * - use typed errors (e.g. ValidationError, MethodNotSupportedError)
-   */
   switch (operationType) {
     case 'query':
       if (method.toUpperCase() !== 'GET') {
@@ -132,8 +128,8 @@ export const validateRequestMethodForOperationType = (
     case 'subscription':
       throw new Error('A "subscription" operation is not supported yet.');
     default:
-      // ignore
-      return;
+      const _exhaustiveCheck: never = operationType;
+      return _exhaustiveCheck;
   }
 };
 

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -8,6 +8,7 @@ import {
 } from 'apollo-link';
 import { hasDirectives, addTypenameToDocument } from 'apollo-utilities';
 import { graphql } from 'graphql-anywhere/lib/async';
+import { Resolver } from 'graphql-anywhere';
 
 export namespace RestLink {
   export type URI = string;
@@ -88,14 +89,21 @@ const getURIFromEndpoints = (
   );
 };
 
-const replaceParam = (endpoint, name, value) => {
+const replaceParam = (
+  endpoint: string,
+  name: string,
+  value: string,
+): string => {
   if (!value || !name) {
     return endpoint;
   }
   return endpoint.replace(`:${name}`, value);
 };
 
-const convertObjectKeys = (object, converter) => {
+const convertObjectKeys = (
+  object: object,
+  converter: (value: string) => string,
+): object => {
   return Object.keys(object)
     .filter(e => e !== '__typename')
     .reduce((acc, val) => {
@@ -114,7 +122,7 @@ const convertObjectKeys = (object, converter) => {
 export const validateRequestMethodForOperationType = (
   method: string,
   operationType: OperationTypeNode,
-) => {
+): void => {
   switch (operationType) {
     case 'query':
       if (method.toUpperCase() !== 'GET') {
@@ -135,7 +143,7 @@ export const validateRequestMethodForOperationType = (
 
 let exportVariables = {};
 
-const resolver = async (fieldName, root, args, context, info) => {
+const resolver: Resolver = async (fieldName, root, args, context, info) => {
   const { directives, isLeaf, resultKey } = info;
   if (root === null) {
     exportVariables = {};


### PR DESCRIPTION
Add additional types to the helpers, the `graphql` `resolver`, and an exhaustiveness check to the `validateRequestMethodForOperationType` function.