### PR TITLE
Update README ✏️

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,70 @@
-# apollo-link-rest
+---
+title: REST Link
+---
 
-## Problem to solve
-You have an existing REST set of services that you have worked on for a long time. However the limitations of it are piling up and you think GraphQL is a great solution to make your application faster and easier to develop. With `apollo-link-rest`, you can start trying out GraphQL without a full server. You can use it to prototype and even use it for third party services that don't yet have a GraphQL endpoint.
+## ⚠️ This library is under active development ⚠️
 
-Apollo Link Rest lets you query traditional REST API endpoints while writing GraphQL. It is designed to work with Apollo Client, but can even be used on its own with Apollo Link.
+This library is under active development. For information on progress check out
+[this issue](https://github.com/apollographql/apollo-link-rest/issues/3) or the
+design [here](./designs/initial.md). We would love your help with writing, docs,
+testing, anything! We would love for you, yes you, to be a part of the Apollo
+community!
 
-## Status
-This library is under active development. For information on progress check out [this issue](https://github.com/apollographql/apollo-link-rest/issues/3) or the design [here](./designs/initial.md). We would love your help! If you want to get involved create or comment on an issue with interest! This could be writing, docs, testing, anything! We would love for you, yes you, to be a part of the Apollo community!
+## Purpose
 
-## Contributing
-This project uses TypeScript to bring static types to JavaScript and uses Jest for testing. To get started, clone the repo and run the following commands:
+An Apollo Link to easily try out GraphQL without a full server. It can be used
+to prototype, with third-party services that don't have a GraphQL endpoint or
+in a transition from REST to GraphQL.
 
-```bash
-npm install # you can also run `yarn`
+## Installation
+
+***Not yet published***
+
+## Usage
+
+```js
+import { RestLink } from "...";
+
+const link = new RestLink({ uri: '/api' });
 ```
 
-To test the library you can run the following:
+## Options
+
+REST Link takes an object with some options on it to customize the behavior of
+the link. The options you can pass are outlined below:
+
+- `uri`: the URI key is a string endpoint (optional when `endpoints` provides
+  a default)
+- `endpoints`: root endpoint (uri) to apply paths to or a map of endpoints
+- `customFetch`: a custom `fetch` to handle REST calls
+- `headers`: an object representing values to be sent as headers on the request
+- `credentials`: a string representing the credentials policy you want for the
+  fetch call
+- `fieldNameNormalizer`: function that takes the response field name and
+  converts it into a GraphQL compliant name
+
+## Context
+
+The REST Link uses the `headers` field on the context to allow passing headers
+to the HTTP request. It also supports the `credentials` field for defining
+credentials policy.
+
+- `headers`: an object representing values to be sent as headers on the request
+- `credentials`: a string representing the credentials policy you want for the
+  fetch call
+
+## Contributing
+
+This project uses TypeScript to bring static types to JavaScript and uses Jest
+for testing. To get started, clone the repo and run the following commands:
 
 ```bash
-npm test # will run all tests once
+npm install # or `yarn`
 
-npm test -- --watch # will run the tests in watch mode, this is super useful when working on the project
+npm test # or `yarn test` to run tests
+npm test -- --watch # run tests in watch mode
+
+npm run check-types # or `yarn check-types` to check TypeScript types
 ```
 
 To run the library locally in another project, you can do the following:

--- a/README.md
+++ b/README.md
@@ -4,21 +4,18 @@ title: REST Link
 
 ## ⚠️ This library is under active development ⚠️
 
-This library is under active development. For information on progress check out
-[this issue](https://github.com/apollographql/apollo-link-rest/issues/3) or the
-design [here](./designs/initial.md). We would love your help with writing, docs,
-testing, anything! We would love for you, yes you, to be a part of the Apollo
-community!
+This library is under active development. For information on progress check out [this issues](https://github.com/apollographql/apollo-link-rest/issues) or [the design](./designs/initial.md). We would love your help with writing, docs, testing, anything! We would love for you, yes you, to be a part of the Apollo community!
 
 ## Purpose
-
-An Apollo Link to easily try out GraphQL without a full server. It can be used
-to prototype, with third-party services that don't have a GraphQL endpoint or
-in a transition from REST to GraphQL.
+An Apollo Link to easily try out GraphQL without a full server. It can be used to prototype, with third-party services that don't have a GraphQL endpoint or in a transition from REST to GraphQL.
 
 ## Installation
 
 ***Not yet published***
+
+```bash
+npm install apollo-link-rest --save # or `yarn add apollo-link-rest`
+```
 
 ## Usage
 
@@ -30,33 +27,25 @@ const link = new RestLink({ uri: '/api' });
 
 ## Options
 
-REST Link takes an object with some options on it to customize the behavior of
-the link. The options you can pass are outlined below:
+REST Link takes an object with some options on it to customize the behavior of the link. The options you can pass are outlined below:
 
-- `uri`: the URI key is a string endpoint (optional when `endpoints` provides
-  a default)
+- `uri`: the URI key is a string endpoint (optional when `endpoints` provides a default)
 - `endpoints`: root endpoint (uri) to apply paths to or a map of endpoints
 - `customFetch`: a custom `fetch` to handle REST calls
 - `headers`: an object representing values to be sent as headers on the request
-- `credentials`: a string representing the credentials policy you want for the
-  fetch call
-- `fieldNameNormalizer`: function that takes the response field name and
-  converts it into a GraphQL compliant name
+- `credentials`: a string representing the credentials policy you want for the fetch call
+- `fieldNameNormalizer`: function that takes the response field name and converts it into a GraphQL compliant name
 
 ## Context
 
-The REST Link uses the `headers` field on the context to allow passing headers
-to the HTTP request. It also supports the `credentials` field for defining
-credentials policy.
+The REST Link uses the `headers` field on the context to allow passing headers to the HTTP request. It also supports the `credentials` field for defining credentials policy.
 
 - `headers`: an object representing values to be sent as headers on the request
-- `credentials`: a string representing the credentials policy you want for the
-  fetch call
+- `credentials`: a string representing the credentials policy you want for the fetch call
 
 ## Contributing
 
-This project uses TypeScript to bring static types to JavaScript and uses Jest
-for testing. To get started, clone the repo and run the following commands:
+This project uses TypeScript to bring static types to JavaScript and uses Jest for testing. To get started, clone the repo and run the following commands:
 
 ```bash
 npm install # or `yarn`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ title: REST Link
 
 ## ⚠️ This library is under active development ⚠️
 
-This library is under active development. For information on progress check out [this issues](https://github.com/apollographql/apollo-link-rest/issues) or [the design](./designs/initial.md). We would love your help with writing, docs, testing, anything! We would love for you, yes you, to be a part of the Apollo community!
+This library is under active development. For information on progress check out [this issues](https://github.com/apollographql/apollo-link-rest/issues) or [the design](./designs/initial.md). We would love your help with writing docs, testing, anything! We would love for you, yes you, to be a part of the Apollo community!
 
 ## Purpose
 An Apollo Link to easily try out GraphQL without a full server. It can be used to prototype, with third-party services that don't have a GraphQL endpoint or in a transition from REST to GraphQL.
@@ -38,7 +38,7 @@ REST Link takes an object with some options on it to customize the behavior of t
 
 ## Context
 
-The REST Link uses the `headers` field on the context to allow passing headers to the HTTP request. It also supports the `credentials` field for defining credentials policy.
+REST Link uses the `headers` field on the context to allow passing headers to the HTTP request. It also supports the `credentials` field for defining credentials policy.
 
 - `headers`: an object representing values to be sent as headers on the request
 - `credentials`: a string representing the credentials policy you want for the fetch call


### PR DESCRIPTION
This is a first pass at updating the README to follow a similar style of the other [`Apollo Link` packages](https://github.com/apollographql/apollo-link/tree/master/packages).

First phase of #22 (still more work to complete fully).

- [x] Adds a clear (temporary) warning at the top that the package is still in development
- [x] Adds a `title` in YAML format
- [x] Adds a concise purpose section
- [x] Adds an empty installation section (pending npm package)
- [x] Adds a basic usage section
- [x] Adds an options overview section
- [x] Adds a context overview section
- [x] Minor updates to the contributing section (does not exist in other `Apollo Link` READMEs, may consider removing before release?)