### PR TITLE
Feature: GraphQL Mutations

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "prettier": "1.7.4",
     "rimraf": "2.6.1",
     "rollup": "0.45.2",
+    "snake-case": "^2.1.0",
     "ts-jest": "21.1.4",
     "typescript": "2.5.1",
     "uglify-js": "3.1.5"

--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -3,7 +3,7 @@ import { ApolloClient } from 'apollo-client';
 import { InMemoryCache } from 'apollo-cache-inmemory';
 import gql from 'graphql-tag';
 import * as camelCase from 'camelcase';
-import snake_case = require('snake-case');
+const snake_case = require('snake-case');
 import * as fetchMock from 'fetch-mock';
 
 import { RestLink } from '../';
@@ -144,7 +144,6 @@ describe('Configuration', () => {
       const snakePost = { id: 1, title_string: 'Love apollo', category_id: 6 };
       const camelPost = { id: 1, titleString: 'Love apollo', categoryId: 6 };
       fetchMock.get('/api/posts/1', snakePost);
-      const intermediatePost = snakePost;
       const resultPost = camelPost;
 
       const getPostQuery = gql`
@@ -177,7 +176,6 @@ describe('Configuration', () => {
       const snakePost = { id: 1, title_string: 'Love apollo', category_id: 6 };
       const camelPost = { id: 1, titleString: 'Love apollo', categoryId: 6 };
       fetchMock.get('/api/posts/1', snakePost);
-      const intermediatePost = snakePost;
       const resultPost = camelPost;
 
       const getPostQuery = gql`
@@ -1171,7 +1169,6 @@ describe('Mutation', () => {
       // the id in this hash simulates the server *assigning* an id for the new post
       const post = { id: '1', title: 'Love apollo' };
       fetchMock.delete('/api/posts/1', post);
-      const resultPost = { __typename: 'Post', ...post };
 
       const replacePostMutation = gql`
         mutation deletePost($id: ID!) {
@@ -1181,7 +1178,7 @@ describe('Mutation', () => {
           }
         }
       `;
-      const response = await makePromise<Result>(
+      await makePromise<Result>(
         execute(link, {
           operationName: 'deletePost',
           query: replacePostMutation,

--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -98,40 +98,40 @@ describe('Configuration', () => {
       expect(data.post.title).toBeDefined();
       expect(data.post.tags[0].name).toBeDefined();
     });
-    // it('fieldNameNormalizer Too Late graphql-anywhere issues/2744', async () => {
-    //   // https://github.com/apollographql/apollo-client/issues/2744
-    //   expect.assertions(1);
+    it.skip('fieldNameNormalizer Too Late graphql-anywhere issues/2744', async () => {
+      // https://github.com/apollographql/apollo-client/issues/2744
+      expect.assertions(1);
 
-    //   const link = new RestLink({
-    //     uri: '/api',
-    //     fieldNameNormalizer: camelCase,
-    //   });
+      const link = new RestLink({
+        uri: '/api',
+        fieldNameNormalizer: camelCase,
+      });
 
-    //   // the id in this hash simulates the server *assigning* an id for the new post
-    //   const snakePost = { id: 1, title_string: 'Love apollo', category_id: 6 };
-    //   const camelPost = { id: 1, titleString: 'Love apollo', categoryId: 6 };
-    //   fetchMock.get('/api/posts/1', snakePost);
-    //   const intermediatePost = snakePost;
-    //   const resultPost = camelPost;
+      // the id in this hash simulates the server *assigning* an id for the new post
+      const snakePost = { id: 1, title_string: 'Love apollo', category_id: 6 };
+      const camelPost = { id: 1, titleString: 'Love apollo', categoryId: 6 };
+      fetchMock.get('/api/posts/1', snakePost);
+      const intermediatePost = snakePost;
+      const resultPost = camelPost;
 
-    //   const getPostQuery = gql`
-    //     query lookupPost($id: String!) {
-    //       post(id: $id) @rest(type: "Post", path: "/posts/1", method: "GET") {
-    //         id
-    //         titleString
-    //         categoryId
-    //       }
-    //     }
-    //   `;
-    //   const response = await makePromise<Result>(
-    //     execute(link, {
-    //       operationName: 'lookupPost',
-    //       query: getPostQuery,
-    //       variables: { id: camelPost.id },
-    //     }),
-    //   );
-    //   expect(response.data.post).toEqual(resultPost);
-    // });
+      const getPostQuery = gql`
+        query lookupPost($id: String!) {
+          post(id: $id) @rest(type: "Post", path: "/posts/1", method: "GET") {
+            id
+            titleString
+            categoryId
+          }
+        }
+      `;
+      const response = await makePromise<Result>(
+        execute(link, {
+          operationName: 'lookupPost',
+          query: getPostQuery,
+          variables: { id: camelPost.id },
+        }),
+      );
+      expect(response.data.post).toEqual(resultPost);
+    });
     it('fieldNameNormalizer Too Late - Workaround 1', async () => {
       expect.assertions(1);
 

--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -97,6 +97,108 @@ describe('Configuration', () => {
       expect(data.post.title).toBeDefined();
       expect(data.post.tags[0].name).toBeDefined();
     });
+    // it('fieldNameNormalizer Too Late graphql-anywhere issues/2744', async () => {
+    //   // https://github.com/apollographql/apollo-client/issues/2744
+    //   expect.assertions(1);
+
+    //   const link = new RestLink({
+    //     uri: '/api',
+    //     fieldNameNormalizer: camelCase,
+    //   });
+
+    //   // the id in this hash simulates the server *assigning* an id for the new post
+    //   const snakePost = { id: 1, title_string: 'Love apollo', category_id: 6 };
+    //   const camelPost = { id: 1, titleString: 'Love apollo', categoryId: 6 };
+    //   fetchMock.get('/api/posts/1', snakePost);
+    //   const intermediatePost = snakePost;
+    //   const resultPost = camelPost;
+
+    //   const getPostQuery = gql`
+    //     query lookupPost($id: String!) {
+    //       post(id: $id) @rest(type: "Post", path: "/posts/1", method: "GET") {
+    //         id
+    //         titleString
+    //         categoryId
+    //       }
+    //     }
+    //   `;
+    //   const response = await makePromise<Result>(
+    //     execute(link, {
+    //       operationName: 'lookupPost',
+    //       query: getPostQuery,
+    //       variables: { id: camelPost.id },
+    //     }),
+    //   );
+    //   expect(response.data.post).toEqual(resultPost);
+    // });
+    it('fieldNameNormalizer Too Late - Workaround 1', async () => {
+      expect.assertions(1);
+
+      const link = new RestLink({
+        uri: '/api',
+        fieldNameNormalizer: camelCase,
+      });
+
+      // the id in this hash simulates the server *assigning* an id for the new post
+      const snakePost = { id: 1, title_string: 'Love apollo', category_id: 6 };
+      const camelPost = { id: 1, titleString: 'Love apollo', categoryId: 6 };
+      fetchMock.get('/api/posts/1', snakePost);
+      const intermediatePost = snakePost;
+      const resultPost = camelPost;
+
+      const getPostQuery = gql`
+        query lookupPost($id: String!) {
+          post(id: $id) @rest(type: "Post", path: "/posts/1", method: "GET") {
+            id
+            title_string
+            category_id
+          }
+        }
+      `;
+      const response = await makePromise<Result>(
+        execute(link, {
+          operationName: 'lookupPost',
+          query: getPostQuery,
+          variables: { id: camelPost.id },
+        }),
+      );
+      expect(response.data.post).toEqual(resultPost);
+    });
+    it('fieldNameNormalizer Too Late - Workaround 2', async () => {
+      expect.assertions(1);
+
+      const link = new RestLink({
+        uri: '/api',
+        fieldNameNormalizer: camelCase,
+      });
+
+      // the id in this hash simulates the server *assigning* an id for the new post
+      const snakePost = { id: 1, title_string: 'Love apollo', category_id: 6 };
+      const camelPost = { id: 1, titleString: 'Love apollo', categoryId: 6 };
+      fetchMock.get('/api/posts/1', snakePost);
+      const intermediatePost = snakePost;
+      const resultPost = camelPost;
+
+      const getPostQuery = gql`
+        query lookupPost($id: String!) {
+          post(id: $id) @rest(type: "Post", path: "/posts/1", method: "GET") {
+            id
+            title_string
+            titleString
+            category_id
+            categoryId
+          }
+        }
+      `;
+      const response = await makePromise<Result>(
+        execute(link, {
+          operationName: 'lookupPost',
+          query: getPostQuery,
+          variables: { id: camelPost.id },
+        }),
+      );
+      expect(response.data.post).toEqual(resultPost);
+    });
   });
 
   describe('Custom fetch', () => {

--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -111,7 +111,6 @@ describe('Configuration', () => {
       const snakePost = { id: 1, title_string: 'Love apollo', category_id: 6 };
       const camelPost = { id: 1, titleString: 'Love apollo', categoryId: 6 };
       fetchMock.get('/api/posts/1', snakePost);
-      const intermediatePost = snakePost;
       const resultPost = camelPost;
 
       const getPostQuery = gql`

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -165,29 +165,6 @@ const convertObjectKeys = (
   converter: RestLink.FieldNameNormalizer,
   keypath: string[] = [],
 ): object => {
-  if (['string', 'number'].indexOf(typeof object) != -1) {
-    // Object is a scalar
-    return object;
-  }
-
-  const perItem = (acc: any, key: string) => {
-    let value = object[key];
-    const nestedKeyPath = keypath.concat([key]);
-    if (typeof value === 'object') {
-      value = convertObjectKeys(value, converter, nestedKeyPath);
-    }
-    if (Array.isArray(value)) {
-      value = value.map(e => convertObjectKeys(e, converter, nestedKeyPath));
-    }
-    acc[convert(key, nestedKeyPath)] = value;
-    return acc;
-  };
-
-  if (Array.isArray(object)) {
-    const { body } = perItem({ body: object }, 'body');
-    return body;
-  }
-
   let convert: RestLink.KeyedFieldNameNormalizer = null;
   if (isSimpleFieldNameNormalizer(converter)) {
     convert = (name, keypath) => {
@@ -197,9 +174,25 @@ const convertObjectKeys = (
     convert = converter;
   }
 
+  if (['string', 'number'].indexOf(typeof object) != -1) {
+    // Object is a scalar, no keys to convert!
+    return object;
+  }
+
   return Object.keys(object)
     .filter(e => e !== '__typename')
-    .reduce(perItem, {});
+    .reduce((acc: any, key: string) => {
+      let value = object[key];
+      const nestedKeyPath = keypath.concat([key]);
+      if (typeof value === 'object') {
+        value = convertObjectKeys(value, converter, nestedKeyPath);
+      }
+      if (Array.isArray(value)) {
+        value = value.map(e => convertObjectKeys(e, converter, nestedKeyPath));
+      }
+      acc[convert(key, nestedKeyPath)] = value;
+      return acc;
+    }, {});
 };
 
 const noOpNameNormalizer: RestLink.SimpleFieldNameNormalizer = (

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -30,15 +30,9 @@ export namespace RestLink {
 
   export type HeadersMergePolicy = (...headerGroups: Headers[]) => Headers;
 
-  export interface SimpleFieldNameNormalizer {
-    (fieldName: string): string;
+  export interface FieldNameNormalizer {
+    (fieldName: string, keypath?: string[]): string;
   }
-  export interface KeyedFieldNameNormalizer {
-    (fieldName: string, keypath: string[]): string;
-  }
-  export type FieldNameNormalizer =
-    | SimpleFieldNameNormalizer
-    | KeyedFieldNameNormalizer;
 
   export type CustomFetch = (
     request: RequestInfo,
@@ -153,20 +147,14 @@ const replaceParam = (
   return endpoint.replace(`:${name}`, value);
 };
 
-function isSimpleFieldNameNormalizer(
-  arg: Function,
-): arg is RestLink.SimpleFieldNameNormalizer {
-  return arg.prototype.arity != 2;
-}
-
 /** Recursively descends the provided object tree and converts all the keys */
 const convertObjectKeys = (
   object: object,
   converter: RestLink.FieldNameNormalizer,
   keypath: string[] = [],
 ): object => {
-  let convert: RestLink.KeyedFieldNameNormalizer = null;
-  if (isSimpleFieldNameNormalizer(converter)) {
+  let convert: RestLink.FieldNameNormalizer = null;
+  if (converter.prototype.arity != 2) {
     convert = (name, keypath) => {
       return converter(name);
     };
@@ -195,9 +183,7 @@ const convertObjectKeys = (
     }, {});
 };
 
-const noOpNameNormalizer: RestLink.SimpleFieldNameNormalizer = (
-  name: string,
-) => {
+const noOpNameNormalizer: RestLink.FieldNameNormalizer = (name: string) => {
   return name;
 };
 

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -78,6 +78,24 @@ export namespace RestLink {
      */
     customFetch?: CustomFetch;
   };
+
+  /** @rest(...) Directive Options */
+  export interface DirectiveOptions {
+    /**
+     * What HTTP method to use.
+     * @default `GET`
+     */
+    method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+    /** What GraphQL type to name the response */
+    type?: string;
+    /** What path to use */
+    path: string;
+    /**
+     * What endpoint to select from the map of endpoints available to this link.
+     * @default `RestLink.endpoints[DEFAULT_ENDPOINT_KEY]`
+     */
+    endpoint?: string;
+  }
 }
 
 const addTypeNameToResult = (
@@ -282,7 +300,6 @@ const resolver: Resolver = async (
     }
     return leafValue;
   }
-  const { path, endpoint } = directives.rest;
   const {
     credentials,
     endpoints,
@@ -290,6 +307,7 @@ const resolver: Resolver = async (
     customFetch,
     operationType,
   } = context;
+  const { path, endpoint } = directives.rest as RestLink.DirectiveOptions;
   const uri = getURIFromEndpoints(endpoints, endpoint);
   try {
     const argsWithExport = { ...args, ...exportVariables };
@@ -302,7 +320,7 @@ const resolver: Resolver = async (
         'Missing params to run query, specify it in the query params or use an export directive',
       );
     }
-    let { method, type } = directives.rest;
+    let { method, type } = directives.rest as RestLink.DirectiveOptions;
     if (!method) {
       method = 'GET';
     }


### PR DESCRIPTION
This PR resolves issue #25 by providing mutation support. PR is ready for comments!

## Tasks

- [x] Support POST Operations
- [x] Support PUT Operations
- [x] Support PATCH Operations
- [x] Support DELETE Operations
- [x] Add optional fieldNameDenormalizer
- [x] Add fieldNameDenormalizer Tests
- [x] Add optional bodyKey
- [x] Add optional bodyBuilder
- [x] Add bodyKey/bodyBuilder Tests
- [x] usage docs added as docs lines in the code.

## Issues Filed

- [`fieldNameNormalizer` relies on `resultMapper` which is being called too late right now #2744](https://github.com/apollographql/apollo-client/issues/2744)
- Add a helper for validating mutation bodies. #30