### PR TITLE
Remove *Not Yet Published* warning in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ An Apollo Link to easily try out GraphQL without a full server. It can be used t
 
 ## Installation
 
-***Not yet published***
-
 ```bash
 npm install apollo-link-rest --save # or `yarn add apollo-link-rest`
 ```


### PR DESCRIPTION
The package is now [published on NPM](https://www.npmjs.com/package/apollo-link-rest). Remove the warning that it is **Not Yet Published** from the `README`. 📝 