### PR TITLE
Fix/Implement RestLink Query Nesting

### DIFF
--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -352,6 +352,52 @@ describe('Query single call', () => {
     expect(data1.post.title).toBe(postV1.title);
     expect(data2.post.titleText).toBe(postV2.titleText);
   });
+
+  it('can make a doubly nested query!', async () => {
+    expect.assertions(1);
+
+    const link = new RestLink({ uri: '/api' });
+    const post = {
+      id: '1',
+      title: 'Love apollo',
+      nested: { data: 'test', secondNestKey: 'proof' },
+    };
+    const postWithNest = { ...post };
+    (postWithNest.nested as any).test = {
+      __typename: 'Inner',
+      positive: 'winning',
+    };
+
+    fetchMock.get('/api/post/1', post);
+    fetchMock.get('/api/post/proof', { positive: 'winning' });
+
+    const postTitleQuery = gql`
+      query postTitle {
+        post @rest(type: "Post", path: "/post/1") {
+          id
+          title
+          nested {
+            data
+            secondNestKey @export(as: innerNest)
+            test @rest(type: "Inner", path: "/post/:innerNest") {
+              positive
+            }
+          }
+        }
+      }
+    `;
+
+    const { data } = await makePromise<Result>(
+      execute(link, {
+        operationName: 'postTitle',
+        query: postTitleQuery,
+      }),
+    );
+
+    expect(data).toMatchObject({
+      post: { ...postWithNest, __typename: 'Post' },
+    });
+  });
 });
 
 describe('Query multiple calls', () => {

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -244,7 +244,6 @@ const resolver: Resolver = async (
   context: RequestContext,
   info: ExecInfo,
 ) => {
-  console.log(info, root);
   const { directives, isLeaf, resultKey } = info;
   if (root === null) {
     exportVariables = {};

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -244,17 +244,22 @@ const resolver: Resolver = async (
   context: RequestContext,
   info: ExecInfo,
 ) => {
+  console.log(info, root);
   const { directives, isLeaf, resultKey } = info;
   if (root === null) {
     exportVariables = {};
   }
-  if (isLeaf) {
-    const leafValue = root[resultKey];
-    if (directives && directives.export) {
-      exportVariables[directives.export.as] = leafValue;
-    }
-    return leafValue;
+
+  const currentNode = (root || {})[resultKey];
+  if (root && directives && directives.export) {
+    exportVariables[directives.export.as] = currentNode;
   }
+
+  const isNotARestCall = !directives || !directives.rest;
+  if (isLeaf || isNotARestCall) {
+    return currentNode;
+  }
+
   const { credentials, endpoints, headers, customFetch } = context;
   const { path, endpoint } = directives.rest;
   const uri = getURIFromEndpoints(endpoints, endpoint);


### PR DESCRIPTION
Fixes Issue #33 by handling non-flat GraphQL queries in RestLink.