### PR TITLE
Add Codesandbox Examples to the README ✏️

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,6 @@ client.query({ query }).then(response => {
 ### Apollo Client & React Apollo
 
 ```js
-// Assuming similar setup above and using the ApolloProvider.
-
 // Standard React Component, using the injected data prop.
 class RepoBase extends React.Component<Props, {}> {
   public render() {


### PR DESCRIPTION
This adds Codesandbox examples, as recommended in #23. This could be a helpful compliment to the examples in #35. Potential users can quickly make a few changes or play around with the example in Codesandbox to understand the idea behind REST Link without cloning the repo. 

Let me know if anyone disagrees or has ideas to enhance this!

[View the rendered README](https://github.com/Skovy/apollo-link-rest/blob/e8d54d4d5c35a15168136175a1cc0a3706c9fd37/README.md) (easier to read than the diff)