### PR TITLE
CustomRequest to override data-fetching

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "apollo-link-rest",
-  "version": "0.0.1-alpha.1",
+  "name": "apollo-link-rest-vm",
+  "version": "0.0.1-alpha.2",
   "description": "Query existing REST services with GraphQL",
   "license": "MIT",
   "main": "./lib/bundle.umd.js",
@@ -9,12 +9,8 @@
   "typings": "./lib/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/apollographql/apollo-link-rest.git"
+    "url": "git+https://github.com/VladimirMilenko/apollo-link-rest.git"
   },
-  "bugs": {
-    "url": "https://github.com/apollographql/apollo-link-rest/issues"
-  },
-  "homepage": "https://github.com/apollographql/apollo-link-rest#readme",
   "scripts": {
     "build:browser":
       "browserify ./lib/bundle.umd.js -o=./lib/bundle.js --i apollo-link --i graphql --i apollo-utilities && npm run minify:browser",

--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -198,7 +198,35 @@ describe('Configuration', () => {
       expect(response.data.post).toEqual(resultPost);
     });
   });
+  describe('Custom getJSON', () => {
+    afterEach(() => {
+      fetchMock.restore();
+    });
+    it('should apply custom getJSON if specified', async () => {
+      expect.assertions(1);
+      const link = new RestLink({
+        uri: '/api',
+        customGetJSON: (uri, options) => Promise.resolve({ title: 'custom' }),
+      });
 
+      const postTitle = gql`
+        query postTitle {
+          post @rest(type: "Post", path: "/post/1") {
+            title
+          }
+        }
+      `;
+
+      const { data } = await makePromise(
+        execute(link, {
+          operationName: 'postTitle',
+          query: postTitle,
+        }),
+      );
+
+      expect(data.post.title).toBe('custom');
+    });
+  });
   describe('Custom fetch', () => {
     afterEach(() => {
       fetchMock.restore();

--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -206,7 +206,7 @@ describe('Configuration', () => {
       expect.assertions(1);
       const link = new RestLink({
         uri: '/api',
-        customGetJSON: (uri, options) => Promise.resolve({ title: 'custom' }),
+        customRequest: (uri, options) => Promise.resolve({ title: 'custom' }),
       });
 
       const postTitle = gql`


### PR DESCRIPTION
Add parameter `customRequest` to override data fetching.
Used to provide developers with ability to make requests in using theirs own preferred libraries for making REST requests.
Usage:
```
 const link = new RestLink({
        uri: '/api',
        customRequest: (uri, options) => Promise.resolve({ title: 'custom' }),
      });
```
`uri` and `options` are passed as same for fetch. So, make sure if you use axios - don't use them as in fetch.


Closes #42 
  