### PR TITLE
🐛 Bug Fix: Array Elements Should Not have [Foo] as their typename

### DIFF
--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -300,9 +300,23 @@ describe('Query single call', () => {
     const tags = [{ name: 'apollo' }, { name: 'graphql' }];
     fetchMock.get('/api/tags', tags);
 
+    // Verify multidimensional array support: https://github.com/apollographql/apollo-client/issues/776
+    const keywordGroups = [
+      [{ name: 'group1.element1' }, { name: 'group1.element2' }],
+      [
+        { name: 'group2.element1' },
+        { name: 'group2.element2' },
+        { name: 'group2.element3' },
+      ],
+    ];
+    fetchMock.get('/api/keywordGroups', keywordGroups);
+
     const tagsQuery = gql`
       query tags {
         tags @rest(type: "[Tag]", path: "/tags") {
+          name
+        }
+        keywordGroups @rest(type: "[ [ Keyword ] ]", path: "/keywordGroups") {
           name
         }
       }
@@ -319,7 +333,8 @@ describe('Query single call', () => {
       ...tag,
       __typename: 'Tag',
     }));
-    expect(data).toMatchObject({ tags: tagsWithTypeName });
+    const keywordGroupsWithTypeName = keywordGroups.map(kg => kg.map(element=>({...element, __typename: 'Keyword'}));
+    expect(data).toMatchObject({ tags: tagsWithTypeName, keywordGroups: keywordGroupsWithTypeName });
   });
 
   it('can filter the query result', async () => {

--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -333,7 +333,7 @@ describe('Query single call', () => {
       ...tag,
       __typename: 'Tag',
     }));
-    const keywordGroupsWithTypeName = keywordGroups.map(kg => kg.map(element=>({...element, __typename: 'Keyword'}));
+    const keywordGroupsWithTypeName = keywordGroups.map(kg => kg.map(element=>({...element, __typename: 'Keyword'})));
     expect(data).toMatchObject({ tags: tagsWithTypeName, keywordGroups: keywordGroupsWithTypeName });
   });
 

--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -317,7 +317,7 @@ describe('Query single call', () => {
 
     const tagsWithTypeName = tags.map(tag => ({
       ...tag,
-      __typename: '[Tag]',
+      __typename: 'Tag',
     }));
     expect(data).toMatchObject({ tags: tagsWithTypeName });
   });

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -116,17 +116,27 @@ export namespace RestLink {
   }
 }
 
-const stripArrayCharsFromTypeName = (typename:string): string => {
-  return typename.replace(/[\[\]]/g, "");
-}
+const popOneSetOfArrayBracketsFromTypeName = (typename: string): string => {
+  const noSpace = typename.replace(/\s/g, '');
+  const sansOneBracketPair = noSpace.replace(
+    /\[(.*)\]/,
+    (str, matchStr, offset, fullStr) => {
+      return (
+        ((matchStr != null && matchStr.length) > 0 ? matchStr : null) || noSpace
+      );
+    },
+  );
+  return sansOneBracketPair;
+};
 
 const addTypeNameToResult = (
   result: any[] | object,
   __typename: string,
 ): any[] | object => {
   if (Array.isArray(result)) {
-    const fixedTypename = stripArrayCharsFromTypeName(__typename);
-    return result.map(e => ({ ...e, __typename: fixedTypename }));
+    const fixedTypename = popOneSetOfArrayBracketsFromTypeName(__typename);
+    // Recursion needed for multi-dimensional arrays
+    return result.map(e => addTypeNameToResult(e, fixedTypename));
   }
   return { ...result, __typename };
 };

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -116,12 +116,17 @@ export namespace RestLink {
   }
 }
 
+const stripArrayCharsFromTypeName = (typename:string): string => {
+  return typename.replace(/[\[\]]/g, "");
+}
+
 const addTypeNameToResult = (
   result: any[] | object,
   __typename: string,
 ): any[] | object => {
   if (Array.isArray(result)) {
-    return result.map(e => ({ ...e, __typename }));
+    const fixedTypename = stripArrayCharsFromTypeName(__typename);
+    return result.map(e => ({ ...e, __typename: fixedTypename }));
   }
   return { ...result, __typename };
 };


### PR DESCRIPTION
I noticed that our tests have the `@rest(type:'[Tag]')` as the [example](https://github.com/apollographql/apollo-link-rest/blob/master/src/__tests__/restLink.ts#L305) for an array of values in our response, but the test as [written](https://github.com/apollographql/apollo-link-rest/blob/master/src/__tests__/restLink.ts#L318-L321) was checking that *each* element had the type of `[Tag]`. That's wrong, to match our cache, each element should have the type of `Tag`