### PR TITLE
🐛 Bug-fix: don’t normalize/denormalize __typename

### DIFF
--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -147,6 +147,11 @@ const replaceParam = (
   return endpoint.replace(`:${name}`, value);
 };
 
+/**
+ * Some keys should be passed through transparently without normalizing/de-normalizing
+ */
+const noMangleKeys = ['__typename'];
+
 /** Recursively descends the provided object tree and converts all the keys */
 const convertObjectKeys = (
   object: object,
@@ -167,19 +172,23 @@ const convertObjectKeys = (
     return object;
   }
 
-  return Object.keys(object)
-    .filter(e => e !== '__typename')
-    .reduce((acc: any, key: string) => {
-      let value = object[key];
-      const nestedKeyPath = keypath.concat([key]);
-      if (Array.isArray(value)) {
-        value = value.map(e => convertObjectKeys(e, converter, nestedKeyPath));
-      } else if (typeof value === 'object') {
-        value = convertObjectKeys(value, converter, nestedKeyPath);
-      }
-      acc[convert(key, nestedKeyPath)] = value;
+  return Object.keys(object).reduce((acc: any, key: string) => {
+    let value = object[key];
+
+    if (noMangleKeys.indexOf(key) !== -1) {
+      acc[key] = value;
       return acc;
-    }, {});
+    }
+
+    const nestedKeyPath = keypath.concat([key]);
+    if (Array.isArray(value)) {
+      value = value.map(e => convertObjectKeys(e, converter, nestedKeyPath));
+    } else if (typeof value === 'object') {
+      value = convertObjectKeys(value, converter, nestedKeyPath);
+    }
+    acc[convert(key, nestedKeyPath)] = value;
+    return acc;
+  }, {});
 };
 
 const noOpNameNormalizer: RestLink.FieldNameNormalizer = (name: string) => {


### PR DESCRIPTION
If users want `__typename` in their query response, but they were also using a `fieldNameNormalizer`/`fieldNameDenormalizer`, we were stripping `__typename` from the final response.

This fixes that, adds a test, and fixes the denormalizer tests to permit `__typename` in their test-conditions.