### PR TITLE
I added a comment about the importance of link order

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ import { RestLink } from "apollo-link-rest";
 // Other necessary imports...
 
 // Create a RestLink for the REST API
+// If you are using multiple link types, restLink should go first.
 const restLink = new RestLink({
   uri: 'https://swapi.co/api/',
 });


### PR DESCRIPTION
When setting restLink up alongside other links, if I ordered the restLink after the httpLink it would ignore the restLink and just call through my httpLink.

Works
`link: from([ stateLink, authMiddleware, restLink, httpLink ])`

Doesn't Work
`link: from([ stateLink, authMiddleware, httpLink, restLink ])`