### PR TITLE
TypePatcher Implementation: Proposal-3 aka Resolver Table

### DIFF
--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -6,8 +6,8 @@ import * as camelCase from 'camelcase';
 const snake_case = require('snake-case');
 import * as fetchMock from 'fetch-mock';
 
-import { RestLink } from '../';
 import {
+  RestLink,
   validateRequestMethodForOperationType,
   normalizeHeaders,
 } from '../restLink';
@@ -42,6 +42,32 @@ describe('Configuration', () => {
       expect.assertions(1);
       expect(() => {
         new RestLink({ uri: '/correct', endpoints: { '': '/mismatched' } });
+      }).toThrow();
+    });
+
+    it('throws when invalid typePatchers', async () => {
+      expect.assertions(3);
+      // If using typescript the typescript compiler protects us against allowing this.
+      // but if people use javascript or force it, we want exceptions to be thrown.
+      const pretendItsJavascript = (arg: any): any => arg;
+
+      expect(() => {
+        new RestLink({
+          uri: '/correct',
+          typePatcher: pretendItsJavascript(-1),
+        });
+      }).toThrow();
+      expect(() => {
+        new RestLink({
+          uri: '/correct',
+          typePatcher: pretendItsJavascript('fail'),
+        });
+      }).toThrow();
+      expect(() => {
+        new RestLink({
+          uri: '/correct',
+          typePatcher: pretendItsJavascript([]),
+        });
       }).toThrow();
     });
 
@@ -234,6 +260,244 @@ describe('Configuration', () => {
     });
   });
 });
+describe('Complex responses need nested __typename insertions', () => {
+  it('can configure typename by providing a custom type-patcher function', async () => {
+    expect.assertions(1);
+
+    const link = new RestLink({
+      uri: '/api',
+      typePatcher: (
+        data: any,
+        outerType: string,
+        rootTypePatcher: RestLink.FunctionalTypePatcher,
+      ) => {
+        const { nested, ...rest } = data;
+        const resultNested = { ...nested, __typename: 'Nested' };
+        return {
+          nested: resultNested,
+          ...rest,
+          // If you pass a single function to type patcher, you're responsible for injecting the outerType
+          __typename: outerType,
+        };
+      },
+    });
+    const post = {
+      id: '1',
+      title: 'Love apollo',
+      nested: { data: 'test' },
+    };
+    const result: any = { ...post, __typename: 'Post' };
+    result.nested = { ...result.nested, __typename: 'Nested' };
+
+    fetchMock.get('/api/post/1', post);
+
+    const postTitleQuery = gql`
+      query postTitle {
+        post @rest(type: "Post", path: "/post/1") {
+          id
+          title
+          nested {
+            data
+          }
+        }
+      }
+    `;
+
+    const { data } = await makePromise<Result>(
+      execute(link, {
+        operationName: 'postTitle',
+        query: postTitleQuery,
+      }),
+    );
+
+    expect(data).toMatchObject({
+      post: result,
+    });
+  });
+  it('can configure typename by providing a custom type-patcher table', async () => {
+    expect.assertions(1);
+
+    const patchIfExists = (
+      data: any,
+      key: string,
+      __typename: string,
+      patcher: RestLink.FunctionalTypePatcher,
+    ) => {
+      const value = data[key];
+      if (value == null) {
+        return {};
+      }
+      const result = { [key]: patcher(value, __typename, patcher) };
+      return result;
+    };
+    const typePatcher: RestLink.TypePatcherTable = {
+      Outer: (
+        obj: any,
+        outerType: string,
+        patchDeeper: RestLink.FunctionalTypePatcher,
+      ) => {
+        if (obj == null) {
+          return obj;
+        }
+
+        return {
+          ...obj,
+          ...patchIfExists(obj, 'inner1', 'Inner1', patchDeeper),
+          ...patchIfExists(
+            obj,
+            'simpleDoubleNesting',
+            'SimpleDoubleNesting',
+            patchDeeper,
+          ),
+          ...patchIfExists(obj, 'nestedArrays', 'NestedArrays', patchDeeper),
+        };
+      },
+      Inner1: (
+        obj: any,
+        outerType: string,
+        patchDeeper: RestLink.FunctionalTypePatcher,
+      ) => {
+        if (obj == null) {
+          return obj;
+        }
+        return {
+          ...obj,
+          ...patchIfExists(obj, 'reused', 'Reused', patchDeeper),
+        };
+      },
+      SimpleDoubleNesting: (
+        obj: any,
+        outerType: string,
+        patchDeeper: RestLink.FunctionalTypePatcher,
+      ) => {
+        if (obj == null) {
+          return obj;
+        }
+
+        return {
+          ...obj,
+          ...patchIfExists(obj, 'inner1', 'Inner1', patchDeeper),
+        };
+      },
+      NestedArrays: (
+        obj: any,
+        outerType: string,
+        patchDeeper: RestLink.FunctionalTypePatcher,
+      ) => {
+        if (obj == null) {
+          return obj;
+        }
+
+        return {
+          ...obj,
+          ...patchIfExists(
+            obj,
+            'singlyArray',
+            'SinglyNestedArrayEntry',
+            patchDeeper,
+          ),
+          ...patchIfExists(
+            obj,
+            'doublyNestedArray',
+            'DoublyNestedArrayEntry',
+            patchDeeper,
+          ),
+        };
+      },
+    };
+
+    const link = new RestLink({ uri: '/api', typePatcher });
+    const root = {
+      id: '1',
+      inner1: { data: 'outer.inner1', reused: { id: 1 } },
+      simpleDoubleNesting: {
+        data: 'dd',
+        inner1: { data: 'outer.SDN.inner1', reused: { id: 2 } },
+      },
+      nestedArrays: {
+        unrelatedArray: ['string', 10],
+        singlyArray: [{ data: 'entry!' }],
+        doublyNestedArray: [[{ data: 'inception.entry!' }]],
+      },
+    };
+    const rootTyped = {
+      __typename: 'Outer',
+      id: '1',
+      inner1: {
+        __typename: 'Inner1',
+        data: 'outer.inner1',
+        reused: { __typename: 'Reused', id: 1 },
+      },
+      simpleDoubleNesting: {
+        __typename: 'SimpleDoubleNesting',
+        data: 'dd',
+        inner1: {
+          __typename: 'Inner1',
+          data: 'outer.SDN.inner1',
+          reused: { __typename: 'Reused', id: 2 },
+        },
+      },
+      nestedArrays: {
+        __typename: 'NestedArrays',
+        unrelatedArray: ['string', 10],
+        singlyArray: [{ __typename: 'SinglyNestedArrayEntry', data: 'entry!' }],
+        doublyNestedArray: [
+          [
+            {
+              __typename: 'DoublyNestedArrayEntry',
+              data: 'inception.entry!',
+            },
+          ],
+        ],
+      },
+    };
+
+    fetchMock.get('/api/outer/1', root);
+
+    const someQuery = gql`
+      query someQuery {
+        outer @rest(type: "Outer", path: "/outer/1") {
+          id
+          inner1 {
+            data
+            reused {
+              id
+            }
+          }
+          simpleDoubleNesting {
+            data
+            inner1 {
+              data
+              reused {
+                id
+              }
+            }
+          }
+          nestedArrays {
+            unrelatedArray
+            singlyArray {
+              data
+            }
+            doublyNestedArray {
+              data
+            }
+          }
+        }
+      }
+    `;
+
+    const { data } = await makePromise<Result>(
+      execute(link, {
+        operationName: 'someOperation',
+        query: someQuery,
+      }),
+    );
+
+    expect(data).toMatchObject({
+      outer: rootTyped,
+    });
+  });
+});
 
 describe('Query single call', () => {
   afterEach(() => {
@@ -300,9 +564,23 @@ describe('Query single call', () => {
     const tags = [{ name: 'apollo' }, { name: 'graphql' }];
     fetchMock.get('/api/tags', tags);
 
+    // Verify multidimensional array support: https://github.com/apollographql/apollo-client/issues/776
+    const keywordGroups = [
+      [{ name: 'group1.element1' }, { name: 'group1.element2' }],
+      [
+        { name: 'group2.element1' },
+        { name: 'group2.element2' },
+        { name: 'group2.element3' },
+      ],
+    ];
+    fetchMock.get('/api/keywordGroups', keywordGroups);
+
     const tagsQuery = gql`
       query tags {
         tags @rest(type: "[Tag]", path: "/tags") {
+          name
+        }
+        keywordGroups @rest(type: "[ [ Keyword ] ]", path: "/keywordGroups") {
           name
         }
       }
@@ -317,9 +595,15 @@ describe('Query single call', () => {
 
     const tagsWithTypeName = tags.map(tag => ({
       ...tag,
-      __typename: '[Tag]',
+      __typename: 'Tag',
     }));
-    expect(data).toMatchObject({ tags: tagsWithTypeName });
+    const keywordGroupsWithTypeName = keywordGroups.map(kg =>
+      kg.map(element => ({ ...element, __typename: 'Keyword' })),
+    );
+    expect(data).toMatchObject({
+      tags: tagsWithTypeName,
+      keywordGroups: keywordGroupsWithTypeName,
+    });
   });
 
   it('can filter the query result', async () => {

--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -261,59 +261,6 @@ describe('Configuration', () => {
   });
 });
 describe('Complex responses need nested __typename insertions', () => {
-  it('can configure typename by providing a custom type-patcher function', async () => {
-    expect.assertions(1);
-
-    const link = new RestLink({
-      uri: '/api',
-      typePatcher: (
-        data: any,
-        outerType: string,
-        rootTypePatcher: RestLink.FunctionalTypePatcher,
-      ) => {
-        const { nested, ...rest } = data;
-        const resultNested = { ...nested, __typename: 'Nested' };
-        return {
-          nested: resultNested,
-          ...rest,
-          // If you pass a single function to type patcher, you're responsible for injecting the outerType
-          __typename: outerType,
-        };
-      },
-    });
-    const post = {
-      id: '1',
-      title: 'Love apollo',
-      nested: { data: 'test' },
-    };
-    const result: any = { ...post, __typename: 'Post' };
-    result.nested = { ...result.nested, __typename: 'Nested' };
-
-    fetchMock.get('/api/post/1', post);
-
-    const postTitleQuery = gql`
-      query postTitle {
-        post @rest(type: "Post", path: "/post/1") {
-          id
-          title
-          nested {
-            data
-          }
-        }
-      }
-    `;
-
-    const { data } = await makePromise<Result>(
-      execute(link, {
-        operationName: 'postTitle',
-        query: postTitleQuery,
-      }),
-    );
-
-    expect(data).toMatchObject({
-      post: result,
-    });
-  });
   it('can configure typename by providing a custom type-patcher table', async () => {
     expect.assertions(1);
 

--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -46,8 +46,8 @@ describe('Configuration', () => {
     });
 
     it('throws when invalid typePatchers', async () => {
-      expect.assertions(3);
-      // If using typescript the typescript compiler protects us against allowing this.
+      expect.assertions(4);
+      // If using typescript, the typescript compiler protects us against allowing this.
       // but if people use javascript or force it, we want exceptions to be thrown.
       const pretendItsJavascript = (arg: any): any => arg;
 
@@ -67,6 +67,14 @@ describe('Configuration', () => {
         new RestLink({
           uri: '/correct',
           typePatcher: pretendItsJavascript([]),
+        });
+      }).toThrow();
+      expect(() => {
+        new RestLink({
+          uri: '/correct',
+          typePatcher: pretendItsJavascript({
+            key: 'my values are not functions',
+          }),
         });
       }).toThrow();
     });

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -79,6 +79,10 @@ export namespace RestLink {
 
     /**
      * Structure to allow you to specify the __typename when you have nested objects in your REST response!
+     * 
+     * @warning: We're not thrilled with this API, and would love a better alternative before we get to 1.0.0
+     *           Please see proposals considered in https://github.com/apollographql/apollo-link-rest/issues/48
+     *           And consider submitting alternate solutions to the problem!
      */
     typePatcher?: TypePatcherTable;
 

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -42,7 +42,6 @@ export namespace RestLink {
   export interface TypePatcherTable {
     [typename: string]: FunctionalTypePatcher;
   }
-  export type TypePatcher = FunctionalTypePatcher | TypePatcherTable;
 
   export type CustomFetch = (
     request: RequestInfo,
@@ -81,7 +80,7 @@ export namespace RestLink {
     /**
      * Structure to allow you to specify the __typename when you have nested objects in your REST response!
      */
-    typePatcher?: TypePatcher;
+    typePatcher?: TypePatcherTable;
 
     /**
      * The credentials policy you want to use for the fetch call.
@@ -516,8 +515,6 @@ export class RestLink extends ApolloLink {
           ...subPatcher(data, outerType, patchDeeper),
         };
       };
-    } else if (typeof typePatcher === 'function') {
-      this.typePatcher = typePatcher as RestLink.FunctionalTypePatcher;
     } else {
       throw new Error(
         'RestLink was configured with a typePatcher of invalid type!',

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -499,7 +499,17 @@ export class RestLink extends ApolloLink {
       this.typePatcher = (result, __typename, _2) => {
         return { __typename, ...result };
       };
-    } else if (!Array.isArray(typePatcher) && typeof typePatcher === 'object') {
+    } else if (
+      !Array.isArray(typePatcher) &&
+      typeof typePatcher === 'object' &&
+      Object.keys(typePatcher)
+        .map(key => typePatcher[key])
+        .reduce(
+          // Make sure all of the values are patcher-functions
+          (current, patcher) => current && typeof patcher === 'function',
+          true,
+        )
+    ) {
       const table: RestLink.TypePatcherTable = typePatcher;
       this.typePatcher = (
         data: any,


### PR DESCRIPTION
This is an experimental implementation of the No.3 proposal in issue #48

## Findings:

- This was pretty easy to implement as compared to #51 
- This was pretty easy to use. It does take a more work to configure than an `@type(…)` directive would (Proposal No.1) -- but the benefit is that calling code doesn't have to constantly deal with knowing all the subtypes that need to be tagged on which fields.