### PR TITLE
Fix the body parsing

### DIFF
--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -1565,7 +1565,7 @@ describe('Mutation', () => {
       expect(requestCall[1]).toEqual(
         expect.objectContaining({
           method: 'POST',
-          body: expect.objectContaining(intermediatePost),
+          body: JSON.stringify(intermediatePost),
         }),
       );
     });
@@ -1622,7 +1622,7 @@ describe('Mutation', () => {
       expect(requestCall[1]).toEqual(
         expect.objectContaining({
           method: 'POST',
-          body: expect.objectContaining(intermediatePost),
+          body: JSON.stringify(intermediatePost),
         }),
       );
     });
@@ -1684,7 +1684,7 @@ describe('Mutation', () => {
       expect(requestCall[1]).toEqual(
         expect.objectContaining({ method: 'POST' }),
       );
-      expect(requestCall[1].body).toMatchObject(post);
+      expect(requestCall[1].body).toEqual(JSON.stringify(post));
     });
 
     it('respects bodyKey for mutations', async () => {
@@ -1782,7 +1782,7 @@ describe('Mutation', () => {
       expect(requestCall[1]).toEqual(
         expect.objectContaining({
           method: 'POST',
-          body: expect.stringMatching(
+          body: JSON.stringify(
             fakeEncryption({ input: { title: post.title } }),
           ),
         }),

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -446,7 +446,7 @@ const resolver: Resolver = async (
       credentials,
       method,
       headers,
-      body,
+      body: body && JSON.stringify(body),
     })
       .then(res => res.json())
       .then(result => addTypeNameToResult(result, type, typePatcher));


### PR DESCRIPTION
## Bug description

For now, the body data are not sent to the server.

For example, the following mutation, 
```gql
fragment PublishablePostInput on REST {
  title: String
}

mutation publishPost($input: PublishablePostInput!) {
  publishedPost(input: $input)
    @rest(type: "Post", path: "/posts/new", method: "POST") {
    id
    title
  }
}
```
will never send `title` to the server.

This is due to the fact that we do a `fetch(url, {body: {title: "plop"}})` instead of `fetch(url, {body: JSON.stringify({title: "plop"})})`.

Note, for the moment we need to set manually the `content-type` to `application/json`, otherwise the `body-parser` of a classic expressjs application will not parse the incomming body.

```js
const link = new RestLink({
  uri: process.env.REACT_APP_API_URL,
  headers: {
    'content-type': 'application/json'
  }
});
```