### PR TITLE
Better error handling for HTTP Status codes (apollo-link-error)

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     {
       "name": "apollo-link-rest",
       "path": "./lib/bundle.min.js",
-      "maxSize": "4 kb"
+      "maxSize": "5 kb"
     }
   ],
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@types/node": "^8.0.53",
     "apollo-cache-inmemory": "^1.1.4",
     "apollo-client": "^2.0.4",
+    "apollo-link-error": "^1.0.5",
     "apollo-link-http": "1.2.0",
     "browserify": "14.5.0",
     "bundlesize": "0.15.3",

--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -1963,7 +1963,7 @@ describe('Apollo client integration', () => {
   it('can catch HTTP Status errors', async () => {
     const link = new RestLink({ uri: '/api' });
 
-    // setop onError link
+    // setup onError link
     const errorLink = onError(opts => {
       const { networkError } = opts;
       if (networkError) console.log(`[Network error]: ${networkError}`);

--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -1981,7 +1981,7 @@ describe('Apollo client integration', () => {
     });
 
     try {
-      const result = await client.query({
+      await client.query({
         query: sampleQuery,
       });
       done.fail('query should throw a network error');
@@ -2008,7 +2008,7 @@ describe('Apollo client integration', () => {
     });
 
     const sub = execute(link, { query: sampleQuery }).subscribe({
-      next: result => {
+      next: () => {
         done.fail('result should not have been called');
       },
       error: e => {


### PR DESCRIPTION
Hi all,

We noticed that we couldn't use apollo-link-error in combination with apollo-link-rest.
I checked the apollo-link-http source code in order to check how they've done it to support apollo-link-error and moved this error handling code to apollo-link-rest.

A test has been added, feel free to give your feedback.

Useful links:
https://github.com/apollographql/apollo-link/blob/master/packages/apollo-link-http/src/httpLink.ts#L104
https://github.com/apollographql/apollo-link/blob/master/packages/apollo-link-http/src/httpLink.ts#L257
https://www.npmjs.com/package/apollo-link-error