### PR TITLE
Fix missing namespace currently breaking build

### DIFF
--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -362,7 +362,7 @@ describe('Configuration', async () => {
         }
       `;
 
-      const { data } = await makePromise(
+      const { data } = await makePromise<Result>(
         execute(link, {
           operationName: 'postTitle',
           query: postTitle,
@@ -1991,7 +1991,7 @@ describe('export directive', () => {
       }
     `;
 
-    const { data } = await makePromise(
+    const { data } = await makePromise<Result>(
       execute(link, {
         operationName: 'postTitle',
         query: postTagExport,

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -360,7 +360,7 @@ const rethrowServerSideError = (
   result: Promise<string>,
   message: string,
 ) => {
-  const error = new Error(message) as ServerError;
+  const error = new Error(message) as RestLink.ServerError;
 
   error.response = response;
   error.statusCode = response.status;


### PR DESCRIPTION
Build breaks currently (`npm run build`)

```
> tsc -p .

src/restLink.ts(363,39): error TS2304: Cannot find name 'ServerError'.
```