### PR TITLE
Bugfix/default endpoint assignment

### DIFF
--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -291,7 +291,7 @@ describe('Configuration', async () => {
 
       console['warn'] = jest.fn(warn);
 
-      const link = new RestLink({
+      new RestLink({
         endpoints: {
           endpointUri: '/api',
         },
@@ -308,7 +308,7 @@ describe('Configuration', async () => {
 
       console['warn'] = jest.fn(warn);
 
-      const link = new RestLink({
+      new RestLink({
         uri: '/api/v1',
         endpoints: {
           endpointUri: '/api/v2',

--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -283,6 +283,41 @@ describe('Configuration', async () => {
       expect(data.post.title).toBe('custom');
     });
   });
+
+  describe('Default endpoint', () => {
+    it('should produce a warning if not specified', async () => {
+      let warning = '';
+      const warn = message => (warning = message);
+
+      console['warn'] = jest.fn(warn);
+
+      const link = new RestLink({
+        endpoints: {
+          endpointUri: '/api',
+        },
+      });
+
+      expect(warning).toBe(
+        'RestLink configured without a default URI. All @rest(…) directives must provide an endpoint key!',
+      );
+    });
+
+    it('should not produce a warning when specified', async () => {
+      let warning = '';
+      const warn = message => (warning = message);
+
+      console['warn'] = jest.fn(warn);
+
+      const link = new RestLink({
+        uri: '/api/v1',
+        endpoints: {
+          endpointUri: '/api/v2',
+        },
+      });
+
+      expect(warning).toBe('');
+    });
+  });
 });
 describe('Complex responses need nested __typename insertions', () => {
   it('can configure typename by providing a custom type-patcher table', async () => {

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -785,7 +785,7 @@ export class RestLink extends ApolloLink {
           "RestLink was configured with a default uri that doesn't match what's passed in to the endpoints map.",
         );
       }
-      this.endpoints[DEFAULT_ENDPOINT_KEY] == uri;
+      this.endpoints[DEFAULT_ENDPOINT_KEY] = uri;
     }
 
     if (this.endpoints[DEFAULT_ENDPOINT_KEY] == null) {


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [ ] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

Fixed the warning `RestLink configured without a default URI. All @rest(…) directives must provide an endpoint key!` being written to the console, even though a default endpoint was specified with the uri configuration.

This was due to the assignment operator having an additional equals symbol, producing the unexpected behaviour of an expression rather than the desired behaviour of an assignment operation.