### PR TITLE
GET request body should be null [Edge]

### DIFF
--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -2110,6 +2110,35 @@ describe('Apollo client integration', () => {
     expect(data.post).toBeDefined();
   });
 
+  it('has an undefined body on GET requests', async () => {
+    expect.assertions(1);
+
+    const link = new RestLink({ uri: '/api' });
+
+    const post = { id: '1', title: 'Love apollo' };
+    fetchMock.get('/api/post/1', post);
+
+    const postTagExport = gql`
+      query {
+        post @rest(type: "Post", path: "/post/1") {
+          id
+          title
+        }
+      }
+    `;
+
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+      link,
+    });
+
+    await client.query({
+      query: postTagExport,
+    });
+
+    expect(fetchMock.lastCall()[1].body).toBeUndefined();
+  });
+
   it('treats absent response fields as optional', async done => {
     // Discovered in: https://github.com/apollographql/apollo-link-rest/issues/74
 

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -676,7 +676,7 @@ const resolver: Resolver = async (
       method = 'GET';
     }
 
-    let body = null;
+    let body = undefined;
     if (
       -1 === ['GET', 'DELETE'].indexOf(method) &&
       operationType === 'mutation'


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [ ] feature
- [x] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

In Edge this library causes `TypeError: Failed to execute 'fetch()' on 'Window': HEAD or GET Requests cannot have a body.`

It seems this is because the `body` passed to `fetch` is set to `null` rather than being `undefined`. It works fine in Edge with that corrected.

Edge version:
```
Microsoft Edge 41.16299.371.0
Microsoft EdgeHTML 16.16299
```
