### PR TITLE
Feat: Add custom body serializer support

### DIFF
--- a/docs/rest.md
+++ b/docs/rest.md
@@ -90,6 +90,7 @@ Construction of `RestLink` takes an options object to customize the behavior of 
 * `fieldNameNormalizer?: /function/`: _optional_ function that takes the response field name and converts it into a GraphQL compliant name. -- This is useful if your `REST` API returns fields that aren't representable as GraphQL, or if you want to convert between `snake_case` field names in JSON to `camelCase` keyed fields.
 * `fieldNameDenormalizer?: /function/`: _optional_ function that takes a GraphQL-compliant field name and converts it back into an endpoint-specific name.
 * `typePatcher: /map-of-functions/`: _optional_ Structure to allow you to specify the `__typename` when you have nested objects in your REST response!
+* `bodySerializer?: /function/`: _optional_ function that takes the body of the request directly before it is passed to the fetch call. Defaults to `JSON.stringify`.
 
 <h3 id="options.endpoints">Multiple endpoints</h3>
 
@@ -272,6 +273,13 @@ Here is one way you might customize `RestLink`:
         bodySnippet...
       }
     },
+    bodySerializer: (body: any) => {
+      const formData = new FormData();
+      for (let key in body) {
+        formData.append(key, body[key]);
+      }
+      return formData;
+    }
   });
 ```
 

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -90,8 +90,9 @@ Construction of `RestLink` takes an options object to customize the behavior of 
 * `fieldNameNormalizer?: /function/`: _optional_ function that takes the response field name and converts it into a GraphQL compliant name. -- This is useful if your `REST` API returns fields that aren't representable as GraphQL, or if you want to convert between `snake_case` field names in JSON to `camelCase` keyed fields.
 * `fieldNameDenormalizer?: /function/`: _optional_ function that takes a GraphQL-compliant field name and converts it back into an endpoint-specific name.
 * `typePatcher: /map-of-functions/`: _optional_ Structure to allow you to specify the `__typename` when you have nested objects in your REST response!
+* `defaultSerializer /function/`: _optional_ function that will be used by the `RestLink` as the default serializer when no `bodySerializer` is defined for a `@rest` call. The function will also be passed the current `Header` set, which can be updated before the request is sent to `fetch`. Default method uses `JSON.stringify` and sets the `Content-Type` to `application/json`.
 * `bodySerializers: /map-of-functions/`: _optional_ Structure to allow the definition of alternative serializers, which can then be specified by their key.
-* `defaultSerializer /function/`: _optional_ function that will be used by the `RestLink` as the default serializer when no `bodySerializer` is defined for a `@rest` call. Default is JSON.
+
 
 
 <h3 id="options.endpoints">Multiple endpoints</h3>
@@ -275,12 +276,13 @@ Here is one way you might customize `RestLink`:
         bodySnippet...
       }
     },
-    bodySerializer: (body: any) => {
+    defaultSerializer: (data: any, headers: Headers) => {
       const formData = new FormData();
       for (let key in body) {
         formData.append(key, body[key]);
       }
-      return formData;
+      headers.set("Content-Type", "x-www-form-encoded")
+      return {body: formData, headers};
     }
   });
 ```
@@ -366,7 +368,7 @@ An `@rest(…)` directive takes two required and several optional arguments:
 * _optional_ `endpoint?: string` key to use when looking up the endpoint in the (optional) `endpoints` table if provided to RestLink at creation time.
 * _optional_ `bodyKey?: string = "input"`: This is the name of the `variable` to use when looking to build a REST request-body for a `PUT` or `POST` request. It defaults to `input` if not supplied.
 * _optional_ `bodyBuilder?: /function/`: If provided, this is the name a `function` that you provided to `variables`, that is called when a request-body needs to be built. This lets you combine arguments or encode the body in some format other than JSON.
-* _optional_ `bodySerializer?: /function/`: function that takes the body of the request directly before it is passed to the fetch call. Defaults to `JSON.stringify`.
+* _optional_ `bodySerializer?: /string | function/`: string key to look up a function in `bodySerializers` or a custom serialization function for the body/headers of this request before it is passed ot the fetch call. Defaults to `JSON.stringify` and setting `Content-Type: application-json`.
 
 <h3 id="rest.arguments.variables">Variables</h3>
 
@@ -443,14 +445,14 @@ If you need to serialize your data differently (say as form-encoded), you can pr
 ```graphql
 mutation encryptedForm(
   $input: PublishablePostInput!,
-  formSerializer: any
+  $formSerializer: any
 ) {
   publishedPost: publish(input: $input)
     @rest(
       type: "Post",
       path: "/posts/new",
       method: "POST",
-      bodySerializer: formSerializer
+      bodySerializer: $formSerializer
     ) {
       id
       title

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -90,7 +90,7 @@ Construction of `RestLink` takes an options object to customize the behavior of 
 * `fieldNameNormalizer?: /function/`: _optional_ function that takes the response field name and converts it into a GraphQL compliant name. -- This is useful if your `REST` API returns fields that aren't representable as GraphQL, or if you want to convert between `snake_case` field names in JSON to `camelCase` keyed fields.
 * `fieldNameDenormalizer?: /function/`: _optional_ function that takes a GraphQL-compliant field name and converts it back into an endpoint-specific name.
 * `typePatcher: /map-of-functions/`: _optional_ Structure to allow you to specify the `__typename` when you have nested objects in your REST response!
-* `bodySerializer?: /function/`: _optional_ function that takes the body of the request directly before it is passed to the fetch call. Defaults to `JSON.stringify`.
+
 
 <h3 id="options.endpoints">Multiple endpoints</h3>
 
@@ -364,6 +364,7 @@ An `@rest(…)` directive takes two required and several optional arguments:
 * _optional_ `endpoint?: string` key to use when looking up the endpoint in the (optional) `endpoints` table if provided to RestLink at creation time.
 * _optional_ `bodyKey?: string = "input"`: This is the name of the `variable` to use when looking to build a REST request-body for a `PUT` or `POST` request. It defaults to `input` if not supplied.
 * _optional_ `bodyBuilder?: /function/`: If provided, this is the name a `function` that you provided to `variables`, that is called when a request-body needs to be built. This lets you combine arguments or encode the body in some format other than JSON.
+* _optional_ `bodySerializer?: /function/`: function that takes the body of the request directly before it is passed to the fetch call. Defaults to `JSON.stringify`.
 
 <h3 id="rest.arguments.variables">Variables</h3>
 
@@ -430,6 +431,45 @@ mutation encryptedPost(
 ```
 
 [Unit Test](https://github.com/apollographql/apollo-link-rest/blob/c9d81ae308e5f61b5ae992061de7abc6cb2f78e0/src/__tests__/restLink.ts#L1847-L1904)
+
+<h5 id="rest.arguments.body.serializer">`bodySerializer`</h5>
+
+If you need to serialize your data differently (say as form-encoded), you can provide a `bodySerializer` instead of relying on the default JSON serialization
+
+```graphql
+mutation encryptedForm(
+  $input: PublishablePostInput!,
+  formSerializer: any
+) {
+  publishedPost: publish(input: $input)
+    @rest(
+      type: "Post",
+      path: "/posts/new",
+      method: "POST",
+      bodySerializer: formSerializer
+    ) {
+      id
+      title
+    }
+}
+```
+
+Where `formSerializer` could be defined as
+
+```typescript
+const formSerializer = (body: any) => {
+  const formData = new FormData();
+  for (let key in body) {
+    if (body.hasOwnProperty(key)) {
+      formData.append(key, body[key]);
+    }
+  }
+
+  return formData;
+}
+
+```
+
 
 <h2 id="export">@export directive</h2>
 

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -171,6 +171,12 @@ export namespace RestLink {
      * @see https://dev-blog.apollodata.com/designing-graphql-mutations-e09de826ed97
      */
     bodyKey?: string;
+
+    /**
+     * Optional field that prepares the request body for transport.
+     * @default function that serializes from JSON.
+     */
+    bodySerializer?: (args: object) => object;
     /**
      * A per-request name denormalizer, this permits special endpoints to have their
      * field names remapped differently from the default.
@@ -714,6 +720,7 @@ const resolver: Resolver = async (
       bodyBuilder,
       bodyKey,
       fieldNameDenormalizer: perRequestNameDenormalizer,
+      bodySerializer,
     } = directives.rest as RestLink.DirectiveOptions;
     if (!method) {
       method = 'GET';
@@ -753,7 +760,7 @@ const resolver: Resolver = async (
       credentials,
       method,
       headers,
-      body: body && JSON.stringify(body),
+      body: body && (bodySerializer || JSON.stringify).call(null, body),
     })
       .then(async res => {
         if (res.status >= 300) {


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [x] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

Adds support for custom body serializers which can be specified in a similar manner to `bodyBuilder`. Defaults to `JSON` if none is specified in order to preserve default behaviour.

cc/ @fbartho 

fixes #96 