### PR TITLE
Move dependencies to peerDependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ dist
 lib
 
 .idea
+.vscode

--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ An Apollo Link to easily try out GraphQL without a full server. It can be used t
 ## Installation
 
 ```bash
-npm install apollo-link-rest --save # or `yarn add apollo-link-rest`
+npm install apollo-link-rest apollo-link graphql graphql-anywhere --save # or `yarn add apollo-link-rest apollo-link graphql graphql-anywhere`
 ```
+
+`apollo-link`, `graphql` and `graphql-anywhere` are peer dependencies needed by `apollo-link-rest`.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -42,12 +42,10 @@
     "check-types":
       "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.tests.json"
   },
-  "dependencies": {
-    "apollo-link": "1.0.7",
-    "graphql-anywhere": "^4.1.0-alpha.0"
-  },
   "peerDependencies": {
-    "graphql": "0.11.7 || ^0.12.3"
+    "apollo-link": ">=1",
+    "graphql": ">=0.11",
+    "graphql-anywhere": ">=4"
   },
   "devDependencies": {
     "@types/graphql": "0.11.5",
@@ -55,6 +53,7 @@
     "@types/node": "8.x",
     "apollo-cache-inmemory": "1.1.x",
     "apollo-client": "2.2.x",
+    "apollo-link": "1.0.7",
     "apollo-link-error": "1.0.x",
     "apollo-link-http": "1.5.x",
     "browserify": "14.5.0",
@@ -64,6 +63,7 @@
     "danger": "1.2.0",
     "fetch-mock": "^5.13.1",
     "graphql": "0.11.7",
+    "graphql-anywhere": "^4.1.0-alpha.0",
     "graphql-tag": "2.5.0",
     "jest": "21.2.1",
     "jest-fetch-mock": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
       "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.tests.json"
   },
   "dependencies": {
-    "apollo-link": "^1.0.7",
+    "apollo-link": "1.0.7",
     "graphql-anywhere": "^4.1.0-alpha.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
fixes #99 

This MR moves `apollo-link` and `graphql-anywhere` from dependencies to peerDependencies to avoid duplication in projects that already include those libraries.

Test plan:

- After making those changes and running `rm -Rf yarn.lock && rm -Rf node_modules && yarn`, `yarn test` and `yarn build` still succeed
- I created a new `create-react-app` project, added all Apollo client dependencies, and ran `yarn link apollo-link-rest`. Project was still able to make a rest query following the readme instructions
- With the libraries installed with `yarn` in the node_modules folder of my `apollo-link-rest`, the link would pull from them, and produces the following bundle size:

![image](https://user-images.githubusercontent.com/433409/39677807-18b4b50c-5136-11e8-8aaf-6bf4e89100fc.png)

- If I remove the node_modules folder from my local `apollo-link-rest`, the `create-react-app` project uses its own dependencies, and produces the following bundle size (which is what the published lib should be now):

![image](https://user-images.githubusercontent.com/433409/39677780-bca1ea00-5135-11e8-8825-8feb2af80202.png)

In the end I didn't change anything to the rollup setup. Let me know what you think or if I'm overlooking anything.
