### PR TITLE
Handle empty responses on 204 and zero Content-Length

### DIFF
--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -93,7 +93,7 @@ export namespace RestLink {
 
     /**
      * A function that takes the response field name and converts it into a GraphQL compliant name
-     * 
+     *
      * @note This is called *before* @see typePatcher so that it happens after
      *       optional-field-null-insertion.
      */
@@ -113,7 +113,7 @@ export namespace RestLink {
      *
      * @note: This is called *after* @see fieldNameNormalizer because that happens
      *        after optional-nulls insertion, and those would clobber normalized names.
-     * 
+     *
      * @warning: We're not thrilled with this API, and would love a better alternative before we get to 1.0.0
      *           Please see proposals considered in https://github.com/apollographql/apollo-link-rest/issues/48
      *           And consider submitting alternate solutions to the problem!
@@ -732,7 +732,9 @@ const resolver: Resolver = async (
       })
       .then(res => {
         context.responses.push(res);
-        return res.json();
+        return res.status === 204 || res.headers.get('Content-Length') === '0'
+          ? {}
+          : res.json()
       })
       .then(
         result =>


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [x] feature
- [ ] blocking
- [x] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

This is a proposed solution for #107, adding support for empty response bodies. When the status is 204 or a Content-Length header is present and zero the body will not be parsed and a default empty object will be returned.