### PR TITLE
Support GraphQL Aliases for nested attributes!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Feature: Support "No-Content" responses! [#107](https://github.com/apollographql/apollo-link-rest/pull/107) [#111](https://github.com/apollographql/apollo-link-rest/pull/111)
 - Fix: Bundle-size / Tree Shaking issues [#99](https://github.com/apollographql/apollo-link-rest/issues/99)
 - Fix: Dependency tweaks to prevent multiple versions of deps [#105](https://github.com/apollographql/apollo-link-rest/issues/105)
+- Fix: GraphQL Nested Aliases - [#113](https://github.com/apollographql/apollo-link-rest/pull/113) [#7](https://github.com/apollographql/apollo-link-rest/issues/7)
 
 
 ### v0.2.4

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -623,7 +623,8 @@ const resolver: Resolver = async (
   const { directives, isLeaf, resultKey } = info;
   const { exportVariables } = context;
 
-  let currentNode = (root || {})[resultKey];
+  // Support GraphQL Aliases! Use fieldName not resultKey to lookup our value
+  let currentNode = (root || {})[fieldName];
   if (root && directives && directives.export) {
     exportVariables[directives.export.as] = currentNode;
   }


### PR DESCRIPTION
Fixes #7

Provides support for Aliases on nested fields in a GraphQL Query.

Related: https://github.com/apollographql/apollo-link-state/pull/251