### PR TITLE
Clone error responses to prevent failure when read more than once

### DIFF
--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -816,11 +816,12 @@ const resolver: Resolver = async (
           // Throw a JSError, that will be available under the
           // "Network error" category in apollo-link-error
           let parsed: any;
+          // responses need to be cloned as they can only be read once
           try {
-            parsed = await res.json();
+            parsed = await res.clone().json();
           } catch (error) {
             // its not json
-            parsed = await res.text();
+            parsed = await res.clone().text();
           }
           rethrowServerSideError(
             res,


### PR DESCRIPTION
Fixes 

https://github.com/apollographql/apollo-link-rest/issues/122

Error messages cannot be read properly. Responses need to be cloned to avoid duplicate reading. Currently the message is always `Already Read` without the actual message or status code.