### PR TITLE
Fix types for ServerError

### DIFF
--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -83,7 +83,7 @@ export namespace RestLink {
    */
   export type ServerError = Error & {
     response: Response;
-    result: Promise<string>;
+    result: any;
     statusCode: number;
   };
 
@@ -577,7 +577,7 @@ export const validateRequestMethodForOperationType = (
  */
 const rethrowServerSideError = (
   response: Response,
-  result: Promise<string>,
+  result: any,
   message: string,
 ) => {
   const error = new Error(message) as RestLink.ServerError;


### PR DESCRIPTION
Hi nice maintainers of `apollo-link-rest`, amazing work so far :)

`RestLink.ServerError` gets its "result" parameter from `await res.clone().json()` which is no longer a Promise since it has "await" in front of it, but the result of that promise. From the official types, this looks to be "any"  - https://github.com/Microsoft/TypeScript/blob/master/lib/lib.dom.d.ts#L2504

As much as it pains me to loose types, I think "any" is the most appropriate type here.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [ ] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->