### PR TITLE
(Fix) Add support for mix mode queries.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "apollo-link": "1.2.x",
     "apollo-link-error": "1.1.x",
     "apollo-link-http": "1.5.x",
+    "apollo-link-state": "^0.4.1",
     "browserify": "16.2.x",
     "bundlesize": "0.17.x",
     "camelcase": "5.0.x",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,27 @@
+/**
+ * Adapted from apollo-link-state/utils.ts
+ */
+import { DocumentNode, DirectiveNode } from 'graphql';
+
+import { checkDocument, removeDirectivesFromDocument } from 'apollo-utilities';
+
+const connectionRemoveConfig = {
+  test: (directive: DirectiveNode) => directive.name.value === 'rest',
+  remove: true,
+};
+
+const removed = new Map();
+export function removeRestSetsFromDocument(query: DocumentNode): DocumentNode {
+  const cached = removed.get(query);
+  if (cached) return cached;
+
+  checkDocument(query);
+
+  const docClone = removeDirectivesFromDocument(
+    [connectionRemoveConfig],
+    query,
+  );
+
+  removed.set(query, docClone);
+  return docClone;
+}


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] has-reproduction
- [ ] feature
- [x] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

This PR adds support for mixed mode queries, i.e. queries where there are other non-rest query parts that need to be forwarded to other links. It should support both sibling queries as well as nested queries. Though based on my tests there are some issues (which may not be related to apollo-link-rest) with some advanced use cases e.g. sending an export variable to a second generation nested field across a link boundary,

```
query {
  authors {
    id @export(as: "authorId")
    recentlyViewedPosts @client {
      id @export(as: "postId")
      # Doesn't seem to resolve the authorId in this case
      post @rest(type: "Post", path: "/posts/{exportVariables.authorId}/{exportVariables.postId}") {
        body
      }
    }
  }
}
```

@fbartho @ivank 

Tests expanded from #137 

Fixes #97 