### PR TITLE
Add the Accept application/json header if not provided

### DIFF
--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -1810,6 +1810,41 @@ describe('Query options', () => {
   });
 
   describe('headers', () => {
+    it('sets the Accept: application/json header if not provided', async () => {
+      expect.assertions(2);
+
+      fetchMock.get('/api/posts', []);
+      const postsQuery = gql`
+        query posts {
+          posts @rest(type: "Post", path: "/posts") {
+            id
+          }
+        }
+      `;
+      const operation = {
+        operationName: 'posts',
+        query: postsQuery,
+      };
+
+      const link1 = new RestLink({ uri: '/api' });
+      await makePromise<Result>(execute(link1, operation));
+
+      const link2 = new RestLink({
+        uri: '/api',
+        headers: {
+          Accept: 'text/plain',
+        },
+      });
+      await makePromise<Result>(execute(link2, operation));
+
+      const requestCalls = fetchMock.calls('/api/posts');
+      expect(orderDupPreservingFlattenedHeaders(requestCalls[0][1])).toEqual([
+        'accept: application/json',
+      ]);
+      expect(orderDupPreservingFlattenedHeaders(requestCalls[1][1])).toEqual([
+        'accept: text/plain',
+      ]);
+    });
     it('adds headers to the request from the context', async () => {
       expect.assertions(2);
 
@@ -1850,6 +1885,7 @@ describe('Query options', () => {
 
       const requestCall = fetchMock.calls('/api/post/1')[0];
       expect(orderDupPreservingFlattenedHeaders(requestCall[1])).toEqual([
+        'accept: application/json',
         'authorization: 1234',
       ]);
     });
@@ -1939,6 +1975,7 @@ describe('Query options', () => {
       expect(orderDupPreservingFlattenedHeaders(requestCall[1])).toEqual([
         'setup: setup',
         'setup: in-context duplicate setup',
+        'accept: application/json',
         'authorization: 1234',
         'context: context',
       ]);
@@ -2059,6 +2096,7 @@ describe('Query options', () => {
       expect(orderedFlattened).toEqual([
         'authorization: initial setup',
         'authorization: context',
+        'accept: application/json',
       ]);
     });
   });

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -1153,6 +1153,12 @@ export class RestLink extends ApolloLink {
       [DEFAULT_SERIALIZER_KEY]: defaultSerializer || DEFAULT_JSON_SERIALIZER,
       ...(bodySerializers || {}),
     };
+
+    if (!this.headers.has('Accept')) {
+      // Since we assume a json body on successful responses set the Accept
+      // header accordingly if it is not provided by the user
+      this.headers.set('Accept', 'application/json');
+    }
   }
 
   public request(


### PR DESCRIPTION
Since a JSON body is assumed when handling successful responses it seems the `Accept: application/json` header should be set by default. The user can still override this header by providing a different value for it, but since parsing any other response format as JSON will fail in any case it doesn't seem like that will ever happen.
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [x] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->