### PR TITLE
Make sure jest only works in src dir

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  roots: ['<rootDir>/src'],
   globals: {
     'ts-jest': {
       babelConfig: false,


### PR DESCRIPTION
If you compile the files and `lib` dir shows up, `jest` runs on it too