### PR TITLE
Add test for returning error on zero content length but status code > 300

### DIFF
--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -2504,6 +2504,44 @@ describe('Mutation', () => {
     });
   });
 
+  it('returns an error on zero Content-Length but status > 300', async () => {
+    expect.assertions(1);
+
+    const link = new RestLink({ uri: '/api' });
+
+    const post = { id: '1', title: 'Love apollo' };
+    fetchMock.post('/api/posts', {
+      headers: { 'Content-Length': 0 },
+      status: 500,
+      body: post,
+    });
+
+    const createPostMutation = gql`
+      fragment PublishablePostInput on REST {
+        title: String
+      }
+
+      mutation publishPost($input: PublishablePostInput!) {
+        publishedPost(input: $input)
+          @rest(type: "Post", path: "/posts", method: "POST") {
+          id
+          title
+        }
+      }
+    `;
+    return await makePromise<Result>(
+      execute(link, {
+        operationName: 'publishPost',
+        query: createPostMutation,
+        variables: { input: { title: post.title } },
+      }),
+    ).catch(e =>
+      expect(e).toEqual(
+        new Error('Response not successful: Received status code 500'),
+      ),
+    );
+  });
+
   describe('fieldNameDenormalizer', () => {
     afterEach(() => {
       fetchMock.restore();


### PR DESCRIPTION
Adding a test for Issue resolved by PR https://github.com/apollographql/apollo-link-rest/pull/152
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [ ] feature
- [ ] blocking
- [x] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->