### PR TITLE
Support non-JSON responses in responseTransformer

### DIFF
--- a/docs/rest.md
+++ b/docs/rest.md
@@ -308,7 +308,7 @@ const link = new RestLink({
 });
 ```
 
-Plaintext responses can be handled by manually parsing and converting them to JSON (using the previously described format that Apollo expects):
+Plaintext, or XML, or otherwise-encoded responses can be handled by manually parsing and converting them to JSON (using the previously described format that Apollo expects):
 
 ```js
 const link = new RestLink({

--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -832,9 +832,9 @@ describe('Can customize/parse the response before passing to Apollo', () => {
 
       const link = new RestLink({
         uri: '/api',
-        responseTransformer: (data, type) => {
+        responseTransformer: async (response, type) => {
           expect(type).toBe('Post');
-
+          const data = await response.json();
           return data.post;
         },
       });
@@ -866,9 +866,9 @@ describe('Can customize/parse the response before passing to Apollo', () => {
 
       const link = new RestLink({
         uri: '/api',
-        responseTransformer: (data, type) => {
+        responseTransformer: async (response, type) => {
           expect(type).toBe('[Post]');
-
+          const data = await response.json();
           return data.posts;
         },
       });
@@ -892,7 +892,7 @@ describe('Can customize/parse the response before passing to Apollo', () => {
   });
 
   describe('with endpoint level `responseTransformer`', () => {
-    it('handles single record responses', async () => {
+    it('handles single record responses', async done => {
       fetchMock.get('/api/v1/posts/1', {
         meta: {},
         post: posts[1],
@@ -900,13 +900,14 @@ describe('Can customize/parse the response before passing to Apollo', () => {
 
       const link = new RestLink({
         // This is purpsefully wrong so that we verify the endpoint one is called
-        responseTransformer: data => data.record,
+        responseTransformer: () =>
+          done.fail('Should have called endpoint.responseTransformer'),
         endpoints: {
           v1: {
             uri: '/api/v1',
-            responseTransformer: (data, type) => {
+            responseTransformer: async (response, type) => {
               expect(type).toBe('Post');
-
+              const data = await response.json();
               return data.post;
             },
           },
@@ -930,23 +931,24 @@ describe('Can customize/parse the response before passing to Apollo', () => {
           __typename: 'Post',
         },
       });
+      done();
     });
 
-    it('handles multiple record responses', async () => {
+    it('handles multiple record responses', async done => {
       fetchMock.get('/api/v1/posts', {
         meta: {},
         posts,
       });
 
       const link = new RestLink({
-        // This is purpsefully wrong so that we verify the endpoint one is called
-        responseTransformer: data => data.collection,
+        responseTransformer: () =>
+          done.fail('Should have called endpoint.responseTransformer'),
         endpoints: {
           v1: {
             uri: '/api/v1',
-            responseTransformer: (data, type) => {
+            responseTransformer: async (response, type) => {
               expect(type).toBe('[Post]');
-
+              const data = await response.json();
               return data.posts;
             },
           },
@@ -968,6 +970,7 @@ describe('Can customize/parse the response before passing to Apollo', () => {
           { title: 'Respect apollo', __typename: 'Post' },
         ],
       });
+      done();
     });
   });
 });


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [x] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->