### PR TITLE
Allow POST/PUT/etc methods in Query operations to utilize a body.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### v0.next
 
+* Remove restriction that only allows request bodies to be built for Mutation operations. [#154](https://github.com/apollographql/apollo-link-rest/issues/154) 
+
 ### v0.6.0
 
 * Feature: responseTransformers allow you to restructure & erase "wrapper" objects from your responses. [#146](https://github.com/apollographql/apollo-link-rest/pull/146)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### v0.next
 
-* Remove restriction that only allows request bodies to be built for Mutation operations. [#154](https://github.com/apollographql/apollo-link-rest/issues/154) 
+* Remove restriction that only allows request bodies to be built for Mutation operations. [#154](https://github.com/apollographql/apollo-link-rest/issues/154) & [#173](https://github.com/apollographql/apollo-link-rest/pull/173)
 
 ### v0.6.0
 

--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -2929,6 +2929,67 @@ describe('Mutation', () => {
         }),
       );
     });
+    it('builds a request body for query operations', async () => {
+      expect.assertions(3);
+
+      const link = new RestLink({ uri: '/api' });
+      const post = { id: '1', title: 'This does not feel very RESTful.' };
+      const resultPost = { __typename: 'Post', ...post };
+      fetchMock.post('/api/post-to-get-post', post);
+
+      const getPostQuery = gql`
+        query getPost($id: ID!) {
+          post(input: { id: $id })
+            @rest(type: "Post", path: "/post-to-get-post", method: "POST") {
+            id
+            title
+          }
+        }
+      `;
+
+      const response = await makePromise<Result>(
+        execute(link, {
+          operationName: 'getPost',
+          query: getPostQuery,
+          variables: { id: '1' },
+        }),
+      );
+
+      expect(response.data.post).toEqual(resultPost);
+
+      const requestCall = fetchMock.calls('/api/post-to-get-post')[0];
+      expect(requestCall[1]).toEqual(
+        expect.objectContaining({ method: 'POST' }),
+      );
+      expect(requestCall[1].body).toEqual(JSON.stringify({ id: '1' }));
+    });
+    it('throws when no body input is provided for HTTP methods other than GET or DELETE', async () => {
+      expect.assertions(1);
+
+      const link = new RestLink({ uri: '/api' });
+
+      const createPostMutation = gql`
+        mutation createPost {
+          sendPost @rest(type: "Post", path: "/posts/new", method: "POST") {
+            id
+            title
+          }
+        }
+      `;
+
+      await makePromise<Result>(
+        execute(link, {
+          operationName: 'createPost',
+          query: createPostMutation,
+        }),
+      ).catch(e =>
+        expect(e).toEqual(
+          new Error(
+            '[GraphQL POST mutation using a REST call without a body]. No `input` was detected. Pass bodyKey, or bodyBuilder to the @rest() directive to resolve this.',
+          ),
+        ),
+      );
+    });
     // TODO: Test for BodyBuilder using context
     // TODO: Test for BodyBuilder using @rest
   });

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -938,24 +938,23 @@ const resolver: Resolver = async (
   if (!method) {
     method = 'GET';
   }
+  if (!bodyKey) {
+    bodyKey = 'input';
+  }
 
   let body = undefined;
   let overrideHeaders: Headers = undefined;
-  if (
-    -1 === ['GET', 'DELETE'].indexOf(method) &&
-    operationType === 'mutation'
-  ) {
+  if (-1 === ['GET', 'DELETE'].indexOf(method)) {
     // Prepare our body!
     if (!bodyBuilder) {
       // By convention GraphQL recommends mutations having a single argument named "input"
       // https://dev-blog.apollodata.com/designing-graphql-mutations-e09de826ed97
 
       const maybeBody =
-        allParams.exportVariables[bodyKey || 'input'] ||
-        allParams.args[bodyKey || 'input'];
+        allParams.exportVariables[bodyKey] || allParams.args[bodyKey];
       if (!maybeBody) {
         throw new Error(
-          '[GraphQL mutation using a REST call without a body]. No `input` was detected. Pass bodyKey, or bodyBuilder to the @rest() directive to resolve this.',
+          `[GraphQL ${operationType} using a REST call without a body]. No \`${bodyKey}\` was detected. Pass bodyKey, or bodyBuilder to the @rest() directive to resolve this.`,
         );
       }
 
@@ -963,6 +962,7 @@ const resolver: Resolver = async (
         return maybeBody;
       };
     }
+
     body = convertObjectKeys(
       bodyBuilder(allParams),
       perRequestNameDenormalizer ||

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -951,10 +951,11 @@ const resolver: Resolver = async (
       // https://dev-blog.apollodata.com/designing-graphql-mutations-e09de826ed97
 
       const maybeBody =
-        allParams.exportVariables[bodyKey] || allParams.args[bodyKey];
+        allParams.exportVariables[bodyKey] ||
+        (allParams.args && allParams.args[bodyKey]);
       if (!maybeBody) {
         throw new Error(
-          `[GraphQL ${operationType} using a REST call without a body]. No \`${bodyKey}\` was detected. Pass bodyKey, or bodyBuilder to the @rest() directive to resolve this.`,
+          `[GraphQL ${method} ${operationType} using a REST call without a body]. No \`${bodyKey}\` was detected. Pass bodyKey, or bodyBuilder to the @rest() directive to resolve this.`,
         );
       }
 


### PR DESCRIPTION
* Remove restriction that only allows request bodies to be built for Mutation operations.

------

This PR resolves #154.

Since v0.5.0, POST and other "Mutation"-y HTTP methods (PUT, PATCH, etc) are now permitted in Query operations. 

Currently, when a query is defined using the `@rest` directive to wrap a POST call which includes a body (eg: `input` argument), the body is silently ignored, despite the request being made as otherwise expected.

This is because a restriction is still in place which prevents them having a body added to the request unless they are part of a Mutation operation. If we're going to allow a POST request to be made from a Query, it makes sense to include support for a body, since in most cases, these requests need them. This PR relaxes that restriction, instead relying solely on the HTTP method to determine whether we should attempt to build a body for the request.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [ ] feature
- [ ] blocking
- [ ] good first review
/label enhancement

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->