### PR TITLE
Fix codesandbox examples - Added qs dependencie

### DIFF
--- a/examples/advanced/package.json
+++ b/examples/advanced/package.json
@@ -9,6 +9,7 @@
     "graphql": "0.x",
     "graphql-anywhere": "4.x",
     "graphql-tag": "2.x",
+    "qs": "^6.6.0",
     "react": "16.x",
     "react-apollo": "2.x",
     "react-dom": "16.x",

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -9,6 +9,7 @@
     "graphql": "0.x",
     "graphql-anywhere": "4.x",
     "graphql-tag": "2.x",
+    "qs": "^6.6.0",
     "react": "16.x",
     "react-apollo": "2.x",
     "react-dom": "16.x",

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -12,6 +12,7 @@
     "graphql": "0.x",
     "graphql-anywhere": "4.x",
     "graphql-tag": "2.x",
+    "qs": "^6.6.0",
     "react": "16.x",
     "react-apollo": "2.x",
     "react-dom": "16.x",


### PR DESCRIPTION
When I tried examples in codesandbox, I see an error about `qs` dependencies.
This PR add `qs` as dependencies in examples.