### PR TITLE
Bugfix: default to empty object when creating new headers

### DIFF
--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -650,7 +650,7 @@ export const normalizeHeaders = (
   if (headers instanceof Headers) {
     return headers;
   } else {
-    return new Headers(headers);
+    return new Headers(headers || {});
   }
 };
 


### PR DESCRIPTION
* Initialise `new Headers()` with an empty object if `headers` is undefined. This prevents IE Edge from throwing an "Invalid argument" error.

Resolves #93.