### PR TITLE
Update Installation Instructions - add `qs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ An Apollo Link to easily try out GraphQL without a full server. It can be used t
 ## Installation
 
 ```bash
-npm install apollo-link-rest apollo-link graphql graphql-anywhere --save # or `yarn add apollo-link-rest apollo-link graphql graphql-anywhere`
+npm install apollo-link-rest apollo-link graphql graphql-anywhere qs --save # or `yarn add apollo-link-rest apollo-link graphql graphql-anywhere`
 ```
 
-`apollo-link`, `graphql` and `graphql-anywhere` are peer dependencies needed by `apollo-link-rest`.
+`apollo-link`, `graphql`, `qs` and `graphql-anywhere` are peer dependencies needed by `apollo-link-rest`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An Apollo Link to easily try out GraphQL without a full server. It can be used t
 ## Installation
 
 ```bash
-npm install apollo-link-rest apollo-link graphql graphql-anywhere qs --save # or `yarn add apollo-link-rest apollo-link graphql graphql-anywhere`
+npm install apollo-link-rest apollo-link graphql graphql-anywhere qs --save # or `yarn add apollo-link-rest apollo-link graphql graphql-anywhere qs`
 ```
 
 `apollo-link`, `graphql`, `qs` and `graphql-anywhere` are peer dependencies needed by `apollo-link-rest`.


### PR DESCRIPTION
Setting up a React/Apollo app from scratch following these instructions, I ran into the issue

```
Could not find dependency: 'qs' relative to '/node_modules/apollo-link-rest/bundle.umd.js'
```

So I've updated the README to instruct users to also install `qs` because it appears to be a peer dependency by `apollo-link-rest`.

/label documentation 