### PR TITLE
Fix: Duplicating Content-Type Header

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,11 @@ module.exports = {
     'ts-jest': {
       babelConfig: false,
       mapCoverage: true,
+      diagnostics:{
+        ignoreCodes: [
+          151001 // Suppress esModuleInterop suggestion that breaks __tests__/restLink.ts
+        ]
+      }
     },
   },
   transform: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,10 @@ module.exports = {
     'ts-jest': {
       babelConfig: false,
       mapCoverage: true,
-      diagnostics:{
+      compilerOptions: {
+        allowJs: true, // Necessary for jest.js
+      },
+      diagnostics: {
         ignoreCodes: [
           151001 // Suppress esModuleInterop suggestion that breaks __tests__/restLink.ts
         ]

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -611,10 +611,10 @@ const convertObjectKeys = (
     // Object is a scalar or null / undefined => no keys to convert!
     return object;
   }
-  
+
   if (object instanceof FileList || object instanceof File) {
     // Object is a FileList or File object => no keys to convert!
-    return object
+    return object;
   }
 
   if (Array.isArray(object)) {
@@ -1090,7 +1090,9 @@ const DEFAULT_JSON_SERIALIZER: RestLink.Serializer = (
   data: any,
   headers: Headers,
 ) => {
-  headers.append('Content-Type', 'application/json');
+  if (!headers.has('content-type')) {
+    headers.append('Content-Type', 'application/json');
+  }
   return {
     body: JSON.stringify(data),
     headers: headers,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "allowJs": true,
     "target": "es5",
     "lib": ["es6", "dom"],
     "module": "es2015",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowJs": true,
     "target": "es5",
     "lib": ["es6", "dom"],
     "module": "es2015",


### PR DESCRIPTION
Prevents content-type header from getting duplicated if somebody sets it globally. Fixes: #185