### PR TITLE
Docs: Add customFetch usage example. Closes #184

### DIFF
--- a/docs/rest.md
+++ b/docs/rest.md
@@ -342,6 +342,10 @@ const link = new RestLink({
 <h3 id=options.example.customFetch>Custom Fetch</h3>
 
 By default, Apollo uses the browsers `fetch` method to handle `REST` requests to your domain/endpoint. The `customFetch` option allows you to specify _your own_ request handler by defining a function that returns a `Promise` with a fetch-response-like object:
+
+<h3 id=options.example.customFetch>Custom Fetch</h3>
+
+By default, Apollo uses the browsers `fetch` method to handle `REST` requests to your domain/endpoint. The `customFetch` option allows you to specify _your own_ request handler by defining a function that returns a `Promise` with a fetch-response-like object:
 ```js
 const link = new RestLink({
   endpoints: "/api",
@@ -352,11 +356,11 @@ const link = new RestLink({
 });
 ```
 
-To resolve your GraphQL queries quickly, Apollo will issue requests to all endpoints as soon as possible. This is generally ok, but can lead to large numbers of `REST` requests to be fired at once; especially for deeply nested queries [(see `@export` directive)](#export). 
+To resolve your GraphQL queries quickly, Apollo will issue requests to relevant endpoints as soon as possible. This is generally ok, but can lead to large numbers of `REST` requests to be fired at once; especially for deeply nested queries [(see `@export` directive)](#export). 
 
-Some endpoints (like public APIs) might enforce _rate limits_, leading to failed responses and unresolved queries in such cases.
+> Some endpoints (like public APIs) might enforce _rate limits_, leading to failed responses and unresolved queries in such cases.
 
-By example, `customFetch` is good place to manage your apps fetch operations. The following implementation makes sure to only issue 2 requests at a time (concurrency) while waiting at least 500ms until the next batch of requests is fired. 
+By example, `customFetch` is a good place to manage your apps fetch operations. The following implementation makes sure to only issue 2 requests at a time (concurrency) while waiting at least 500ms until the next batch of requests is fired. 
 ```js
 import pThrottle from "p-throttle";
 

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -342,10 +342,6 @@ const link = new RestLink({
 <h3 id=options.example.customFetch>Custom Fetch</h3>
 
 By default, Apollo uses the browsers `fetch` method to handle `REST` requests to your domain/endpoint. The `customFetch` option allows you to specify _your own_ request handler by defining a function that returns a `Promise` with a fetch-response-like object:
-
-<h3 id=options.example.customFetch>Custom Fetch</h3>
-
-By default, Apollo uses the browsers `fetch` method to handle `REST` requests to your domain/endpoint. The `customFetch` option allows you to specify _your own_ request handler by defining a function that returns a `Promise` with a fetch-response-like object:
 ```js
 const link = new RestLink({
   endpoints: "/api",

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -339,6 +339,39 @@ const link = new RestLink({
 
 > When using the object form, the `uri` field is required.
 
+<h3 id=options.example.customFetch>Custom Fetch</h3>
+
+By default, Apollo uses the browsers `fetch` method to handle `REST` requests to your domain/endpoint. The `customFetch` option allows you to specify _your own_ request handler by defining a function that returns a `Promise` with a fetch-response-like object:
+```js
+const link = new RestLink({
+  endpoints: "/api",
+  customFetch: (uri, options) => new Promise((resolve, reject) => {
+    // Your own (asynchronous) request handler
+    resolve(responseObject)
+  }),
+});
+```
+
+To resolve your GraphQL queries quickly, Apollo will issue requests to all endpoints as soon as possible. This is generally ok, but can lead to large numbers of `REST` requests to be fired at once; especially for deeply nested queries [(see `@export` directive)](#export). 
+
+Some endpoints (like public APIs) might enforce _rate limits_, leading to failed responses and unresolved queries in such cases.
+
+By example, `customFetch` is good place to manage your apps fetch operations. The following implementation makes sure to only issue 2 requests at a time (concurrency) while waiting at least 500ms until the next batch of requests is fired. 
+```js
+import pThrottle from "p-throttle";
+
+const link = new RestLink({
+  endpoints: "/api",
+  customFetch: pThrottle((uri, config) => {
+      return fetch(uri, config);
+    },
+    2, // Max. concurrent Requests
+    500 // Min. delay between calls
+  ),
+});
+```
+> Since Apollo issues `Promise` based requests, we can resolve them as we see fit. This example uses [`pThrottle`](https://github.com/sindresorhus/p-throttle); part of the popular [promise-fun](https://github.com/sindresorhus/promise-fun) collection.
+
 <h3 id=options.example>Complete options</h3>
 
 Here is one way you might customize `RestLink`:


### PR DESCRIPTION
This is a documentation based solution to the issue discussed here: https://github.com/apollographql/apollo-link-rest/issues/184

Please let me know if there are questions or adjustments necessary. Below a direct markdown cc for review.

Best
Dino

-----
<h3 id=options.example.customFetch>Custom Fetch</h3>

By default, Apollo uses the browsers `fetch` method to handle `REST` requests to your domain/endpoint. The `customFetch` option allows you to specify _your own_ request handler by defining a function that returns a `Promise` with a fetch-response-like object:
```js
const link = new RestLink({
  endpoints: "/api",
  customFetch: (uri, options) => new Promise((resolve, reject) => {
    // Your own (asynchronous) request handler
    resolve(responseObject)
  }),
});
```

To resolve your GraphQL queries quickly, Apollo will issue requests to relevant endpoints as soon as possible. This is generally ok, but can lead to large numbers of `REST` requests to be fired at once; especially for deeply nested queries [(see `@export` directive)](#export). 

> Some endpoints (like public APIs) might enforce _rate limits_, leading to failed responses and unresolved queries in such cases.

By example, `customFetch` is a good place to manage your apps fetch operations. The following implementation makes sure to only issue 2 requests at a time (concurrency) while waiting at least 500ms until the next batch of requests is fired. 
```js
import pThrottle from "p-throttle";

const link = new RestLink({
  endpoints: "/api",
  customFetch: pThrottle((uri, config) => {
      return fetch(uri, config);
    },
    2, // Max. concurrent Requests
    500 // Min. delay between calls
  ),
});
```
> Since Apollo issues `Promise` based requests, we can resolve them as we see fit. This example uses [`pThrottle`](https://github.com/sindresorhus/p-throttle); part of the popular [promise-fun](https://github.com/sindresorhus/promise-fun) collection.

-----

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [ ] feature
- [ ] blocking
- [x] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->