### PR TITLE
Add `Related Libraries` section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,5 +113,5 @@ npm link apollo-link-rest
 
 ## Related Libraries
 
-[JSON API Link](https://github.com/Rsullivan00/apollo-link-json-api/) provides
+- [JSON API Link](https://github.com/Rsullivan00/apollo-link-json-api/) provides
 tooling for using GraphQL with JSON API compliant APIs.

--- a/README.md
+++ b/README.md
@@ -110,3 +110,8 @@ npm link
 # in the project you want to run this in
 npm link apollo-link-rest
 ```
+
+## Related Libraries
+
+[JSON API Link](https://github.com/Rsullivan00/apollo-link-json-api/) provides
+tooling for using GraphQL with JSON API compliant APIs.


### PR DESCRIPTION
Adds a `Related Libaries` section to the end of the readme, linking to a JSON API specific implementation.