### PR TITLE
Fix usage of RequestCredentials in React Native

### DIFF
--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -164,7 +164,7 @@ export namespace RestLink {
     /**
      * The credentials policy you want to use for the fetch call.
      */
-    credentials?: RequestCredentials;
+    credentials?: 'omit' | 'same-origin' | 'include';
 
     /**
      * Use a custom fetch to handle REST calls.


### PR DESCRIPTION
React Native doesn't export RequestCredentials, then let's just use
the same enumeration options so it works in both environments.

Closes: #218 