### PR TITLE
feat(restLink): add Headers polyfill when Headers is undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
     "snake-case": "2.1.x",
     "ts-jest": "23.10.x",
     "typescript": "3.x",
-    "uglify-js": "3.4.x"
+    "uglify-js": "3.4.x",
+    "fetch-headers": "2.0.0"
   },
   "resolutions": {
     "babel-core": "7.0.0-bridge.0",

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -32,6 +32,11 @@ import { Resolver, ExecInfo } from 'graphql-anywhere';
 import * as qs from 'qs';
 import { removeRestSetsFromDocument } from './utils';
 
+// Make sure Headers is always defined before used with polyfill hack.
+if (typeof Headers === 'undefined') {
+  const Headers = require('fetch-headers');
+}
+
 export namespace RestLink {
   export type URI = string;
 


### PR DESCRIPTION
Add Headers polyfill when Headers is undefined in some special browser environment.

- [x] feature
