### PR TITLE
feat(Headers): add support when Headers is undefined in browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     {
       "name": "apollo-link-rest",
       "path": "./lib/bundle.min.js",
-      "maxSize": "9.5 kb"
+      "maxSize": "12 kb"
     }
   ],
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
     "snake-case": "2.1.x",
     "ts-jest": "23.10.x",
     "typescript": "3.x",
-    "uglify-js": "3.4.x"
+    "uglify-js": "3.4.x",
+    "fetch-headers": "2.0.0"
   },
   "resolutions": {
     "babel-core": "7.0.0-bridge.0",

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -684,9 +684,10 @@ export const concatHeadersMergePolicy: RestLink.HeadersMergePolicy = (
     if (!current.forEach) {
       current = normalizeHeaders(current);
     }
-    current.forEach((value, key) => {
-      accumulator.append(key, value);
-    });
+
+    for (let key in current) {
+      accumulator.append(key, current[key]);
+    }
 
     return accumulator;
   }, new Headers());

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -35,7 +35,7 @@ import { removeRestSetsFromDocument } from './utils';
 // Make sure Headers is always defined before used with polyfill hack.
 if (typeof Headers === 'undefined') {
   // @ts-ignore
-  const Headers = require('fetch-headers');
+  const Headers = require('fetch-headers/headers-es5.min.js');
 }
 
 export namespace RestLink {

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -34,6 +34,7 @@ import { removeRestSetsFromDocument } from './utils';
 
 // Make sure Headers is always defined before used with polyfill hack.
 if (typeof Headers === 'undefined') {
+  // @ts-ignore
   const Headers = require('fetch-headers');
 }
 

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -684,8 +684,10 @@ export const concatHeadersMergePolicy: RestLink.HeadersMergePolicy = (
     if (!current.forEach) {
       current = normalizeHeaders(current);
     }
-
+    
+    // @ts-ignore
     for (let key in current) {
+      // @ts-ignore
       accumulator.append(key, current[key]);
     }
 

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -32,6 +32,11 @@ import { Resolver, ExecInfo } from 'graphql-anywhere';
 import * as qs from 'qs';
 import { removeRestSetsFromDocument } from './utils';
 
+// Make sure Headers is always defined before used with polyfill hack.
+if (typeof Headers === 'undefined') {
+  const Headers = require('fetch-headers');
+}
+
 export namespace RestLink {
   export type URI = string;
 


### PR DESCRIPTION
Add Headers polyfill when Headers is undefined in some special browser environment like weixin.
It does not has any related to window or Headers.

- [x] feature