### PR TITLE
Add SDL for rest directive

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1,0 +1,50 @@
+scalar RestFunction
+union RestFunctionOrString = String | RestFunction
+
+"""
+Set up the endpoint you want to fetch over REST. The rest directive could be used
+at any depth in a query, but once it is used, nothing nested in it can be GraphQL
+data, it has to be from the RestLink or other resource (like the @client directive)
+"""
+directive @rest(
+  """
+  The GraphQL type this will return
+  """
+  type: String!
+  """
+  URI-path to the REST API. This could be a path or a full URL. If a path, the
+  endpoint given on link creation or from the context is concatenated with it to
+  produce a full `URI`. See also: `pathBuilder`
+  """
+  path: String!
+  """
+  The HTTP method to send the request via (i.e GET, PUT, POST)
+  """
+  method: String
+  """
+  Key to use when looking up the endpoint in the (optional) `endpoints` table if
+  provided to `RestLink` at creation time.
+  """
+  endpoint: String
+  """
+  If provided, this function gets to control what path is produced for this request.
+  """
+  pathBuilder: RestFunction
+  """
+  This is the name of the variable to use when looking to build a REST request-body
+  for a `PUT` or `POST` request. It defaults to `input` if not supplied.
+  """
+  bodyKey: String = "input"
+  """
+  If provided, this is the name a `function` that you provided to `variables`, that is
+  called when a request-body needs to be built. This lets you combine arguments or
+  encode the body in some format other than JSON.
+  """
+  bodyBuilder: RestFunction
+  """
+  String key to look up a function in `bodySerializers` or a custom serialization
+  function for the body/headers of this request before it is passed to the fetch call.
+  Defaults to `JSON.stringify` and setting `Content-Type: application-json`.
+  """
+  bodySerializer: RestFunctionOrString
+) on FIELD

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -47,6 +47,7 @@ node -e "var package = require('./package.json'); \
 # Copy few more files to ./npm
 cp README.md npm/
 cp LICENSE npm/
+cp schema.graphql npm/
 
 echo "deploying to npm…"
 (cd npm && npm publish) || (>&2 echo "If this failed with ENEEDAUTH, remember that 'yarn deploy' won't work because yarn hot-patches npm's registry to yarn pkg.com")


### PR DESCRIPTION
Since version 1.10.0 of the Apollo VS Code extension, which by default requires definitions for all directives, I believe `apollo-link-rest` should provide a schema definition for the `@rest` directive. This definition can then be used as follows in the `apollo.config.js` file that the VS Code extension reads:

```javascript
var apolloRestSchema = require.resolve('apollo-link-rest/schema.graphql');

module.exports = {
  client: {
    name: 'Space Explorer [web]',
    service: 'apollographql-8341',
    includes: [
      'src/**/*.{ts,tsx,js,jsx,graphql,gql}',
      apolloRestSchema
    ]
  }
};
```

This will allow developers to validate their use of directives and provide many IntelliSense features, such as autocompletion and argument information on hover for directives. A history of the relevant VS Code changes can be found here: https://github.com/apollographql/apollo-tooling/pull/1433

---

Here is a similar PR for `apollo-client`: https://github.com/apollographql/apollo-client/pull/5205