### PR TITLE
Allow endpoint-specific field normalization/denormalization

### DIFF
--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -40,6 +40,8 @@ export namespace RestLink {
   export interface EndpointOptions {
     uri: Endpoint;
     responseTransformer?: ResponseTransformer | null;
+    fieldNameNormalizer?: FieldNameNormalizer;
+    fieldNameDenormalizer?: FieldNameNormalizer;
   }
 
   export interface Endpoints {
@@ -991,6 +993,7 @@ const resolver: Resolver = async (
     body = convertObjectKeys(
       bodyBuilder(allParams),
       perRequestNameDenormalizer ||
+        endpointOption.fieldNameDenormalizer ||
         linkLevelNameDenormalizer ||
         noOpNameNormalizer,
     );
@@ -1080,8 +1083,9 @@ const resolver: Resolver = async (
     result = await result.json();
   }
 
-  if (fieldNameNormalizer !== null) {
-    result = convertObjectKeys(result, fieldNameNormalizer);
+  const normalizer = endpointOption.fieldNameNormalizer || fieldNameNormalizer;
+  if (normalizer !== null) {
+    result = convertObjectKeys(result, normalizer);
   }
 
   result = findRestDirectivesThenInsertNullsForOmittedFields(


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [x] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

Allows clients to specify field name normalization/denormalizations on a per-endpoint basis. This would be useful in cases where (for instance) one endpoint picks PascalCase for their field names and another picks camelCase, and you want to standardize on one or the other in your code.

This could be worked-around using a responseTransformer and per-request denormalizers, but that feels pretty heavy for this specific type of transformation.

Implements the feature described in #232 