### PR TITLE
Fix undefined exported variables inside type patched nodes

### DIFF
--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -3630,7 +3630,7 @@ describe('export directive', () => {
       query userPostsWithTagDetails {
         user @rest(path: "/user") {
           id
-          posts {
+          posts @type(name: "Post") {
             id @export(as: "postId")
             tags {
               id @export(as: "tagId")

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -869,7 +869,8 @@ const resolver: Resolver = async (
         'Invalid use of @type(name: ...) directive on a call that also has @rest(...)',
       );
     }
-    addTypeToNode(preAliasingNode, directives.type.name);
+    copyExportVariables(aliasedNode || preAliasingNode);
+    return addTypeToNode(preAliasingNode, directives.type.name);
   }
 
   const isNotARestCall = !directives || !directives.rest;

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -863,6 +863,7 @@ const resolver: Resolver = async (
   if (!isLeaf && isATypeCall) {
     // @type(name: ) is only supported inside apollo-link-rest at this time
     // so use the preAliasingNode as we're responsible for implementing aliasing!
+    // Also: exit early, since @type(name: ) && @rest() can't both exist on the same node.
     if (directives.rest) {
       throw new Error(
         'Invalid use of @type(name: ...) directive on a call that also has @rest(...)',

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -869,7 +869,7 @@ const resolver: Resolver = async (
         'Invalid use of @type(name: ...) directive on a call that also has @rest(...)',
       );
     }
-    copyExportVariables(aliasedNode || preAliasingNode);
+    copyExportVariables(preAliasingNode);
     return addTypeToNode(preAliasingNode, directives.type.name);
   }
 

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -863,13 +863,12 @@ const resolver: Resolver = async (
   if (!isLeaf && isATypeCall) {
     // @type(name: ) is only supported inside apollo-link-rest at this time
     // so use the preAliasingNode as we're responsible for implementing aliasing!
-    // Also: exit early, since @type(name: ) && @rest() can't both exist on the same node.
     if (directives.rest) {
       throw new Error(
         'Invalid use of @type(name: ...) directive on a call that also has @rest(...)',
       );
     }
-    return addTypeToNode(preAliasingNode, directives.type.name);
+    addTypeToNode(preAliasingNode, directives.type.name);
   }
 
   const isNotARestCall = !directives || !directives.rest;


### PR DESCRIPTION
Prevents exported variables from being `undefined` when `@export(as: "var")` is used inside nodes that have been patched by the `@type` directive.