### PR TITLE
fix fieldNameNormalizer mangling ArrayBuffer/Blob types

### DIFF
--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -609,7 +609,17 @@ const convertObjectKeys = (
     converter = __converter;
   }
 
-  if (object == null || typeof object !== 'object') {
+  if (Array.isArray(object)) {
+    return object.map((o, index) =>
+      convertObjectKeys(o, converter, [...keypath, String(index)]),
+    );
+  }
+
+  if (
+    object == null ||
+    typeof object !== 'object' ||
+    object.constructor !== Object
+  ) {
     // Object is a scalar or null / undefined => no keys to convert!
     return object;
   }
@@ -622,12 +632,6 @@ const convertObjectKeys = (
   ) {
     // Object is a FileList or File object => no keys to convert!
     return object;
-  }
-
-  if (Array.isArray(object)) {
-    return object.map((o, index) =>
-      convertObjectKeys(o, converter, [...keypath, String(index)]),
-    );
   }
 
   return Object.keys(object).reduce((acc: any, key: string) => {


### PR DESCRIPTION
Fix bug situation.

currently fieldNameNormalizer makes ArrayBuffer or Blob to {};
especially use it with responseTransformer.

for example, 
```
const restLink = new RestLink({
  credentials: 'same-origin',
  uri: getAPIPrefix(),
  endpoints: {
    pdfSource: {
      uri: DIRECT_PDF_PATH_PREFIX,
      responseTransformer: async res => {
        // res is the binary data
        const data = await res.arrayBuffer();
        return { data };
      },
    },
  },
  fieldNameNormalizer: (key: string) => {
    return camelCase(key);
  },
});
```

after using `useQuery`, data always return {};
Because `convertObjectKeys` function thinks of `Blob` of `ArrayBlob` as a normal `Object` that could be serialized.


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [X] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->