### PR TITLE
Fix handling of empty JSON object response and no field selection

### DIFF
--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -1183,6 +1183,8 @@ export class RestLink extends ApolloLink {
 
     if (typePatcher == null) {
       this.typePatcher = (result, __typename, _2) => {
+        if (!Object.keys(result).length) return null;
+
         return { __typename, ...result };
       };
     } else if (
@@ -1202,6 +1204,8 @@ export class RestLink extends ApolloLink {
         outerType: string,
         patchDeeper: RestLink.FunctionalTypePatcher,
       ) => {
+        if (!Object.keys(data).length) return null;
+
         const __typename = data.__typename || outerType;
         if (Array.isArray(data)) {
           return data.map(d => patchDeeper(d, __typename, patchDeeper));

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -392,6 +392,7 @@ function insertNullsForAnyOmittedFields(
   currentSelectionSet: SelectionSetNode,
 ): void {
   if (
+    currentSelectionSet == null ||
     null == current ||
     typeof current === 'number' ||
     typeof current === 'boolean' ||


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [ ] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

Background: I have to work against an API where certain `DELETE` requests will respond happily with that empty `{}` object, and apollo-rest-link asplodes.


This PR makes it so that a `{}` 200 API response succesfully becomes a `null` when no fields have been requested, as there is no such thing as an empty object in GraphQL.

Not sure whether this would be considered a bugfix or a new feature, I couldn't find any prior discussion about behavior for this scenario.