### PR TITLE
Allowing 404's to be handled as network errors

### DIFF
--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -1722,42 +1722,6 @@ describe('Query multiple calls', () => {
     expect(data.post).toBeDefined();
     expect(data.post.tags).toBeDefined();
   });
-
-  it('can return a partial result if one out of multiple rest calls fail', async () => {
-    expect.assertions(2);
-
-    const link = new RestLink({ uri: '/api' });
-
-    fetchMock.get('/api/post/1', {
-      status: 404,
-      body: { status: 'error', message: 'Not found' },
-    });
-
-    const tags = [{ name: 'apollo' }, { name: 'graphql' }];
-    fetchMock.get('/api/tags', tags);
-
-    const postAndTags = gql`
-      query postAndTags {
-        post @rest(type: "Post", path: "/post/1") {
-          id
-          title
-        }
-        tags @rest(type: "[Tag]", path: "/tags") {
-          name
-        }
-      }
-    `;
-
-    const { data } = await toPromise<Result>(
-      execute(link, {
-        operationName: 'postAndTags',
-        query: postAndTags,
-      }),
-    );
-
-    expect(data.tags).toBeDefined();
-    expect(data.post).toBeNull();
-  });
 });
 
 describe('GraphQL aliases should work', async () => {

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -1047,10 +1047,6 @@ const resolver: Resolver = async (
     } else {
       result = response;
     }
-  } else if (response.status === 404) {
-    // In a GraphQL context a missing resource should be indicated by
-    // a null value rather than throwing a network error
-    result = null;
   } else {
     // Default error handling:
     // Throw a JSError, that will be available under the


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [x] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->
`/label error handling`

Based on [many](https://stackoverflow.blog/2020/03/02/best-practices-for-rest-api-design/)  [rest](https://stoplight.io/blog/rest-api-standards-do-they-even-exist/) [api](https://github.com/paypal/api-standards/blob/master/api-style-guide.md#error-handling) [standards](https://www.vinaysahni.com/best-practices-for-a-pragmatic-restful-api#http-status), all error codes should always include a human-readable message. Nulling that result, is in direct opposition to that. 404's should be handled as any other network/client error is handled. This nulls it out before I can even access it to map it elsewhere and force the error to come across.

A missing resource from the server side REST API response will throw a 404, good REST API standards all recommend servers pass through a body with a human readable message along with it, to expose to the UI. As such, 404's should be handled as networkErrors along with all other 4xx errors in restlink