### PR TITLE
Fix typo when defining type for bodySerializer on 'bodySerializer' section

### DIFF
--- a/docs/rest.md
+++ b/docs/rest.md
@@ -594,7 +594,7 @@ mutation encryptedPost(
 ##### `bodySerializer`
 
 If you need to serialize your data differently (say as form-encoded), you can provide a `bodySerializer` instead of relying on the default JSON serialization.
-`bodySerializer` can be either a function of the form `(data: any, headers: Headers) => {body: any, header: Headers}` or a string key. When using the string key
+`bodySerializer` can be either a function of the form `(data: any, headers: Headers) => {body: any, headers: Headers}` or a string key. When using the string key
 `RestLink` will instead use the corresponding serializer from the `bodySerializers` object that can optionally be passed in during initialization.
 
 ```graphql


### PR DESCRIPTION
Closes: https://github.com/apollographql/apollo-link-rest/issues/284

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [ ] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
/label fix-docs-typo

-->