### PR TITLE
chore: inline graphql-anywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ or
 yarn add apollo-link-rest apollo-link graphql qs
 ```
 
-`apollo-link`, `graphql` and `qs` are peer dependencies needed by `apollo-link-rest`.
+`apollo-link`, `graphql`, and `qs` are peer dependencies needed by `apollo-link-rest`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ An Apollo Link to easily try out GraphQL without a full server. It can be used t
 ## Installation
 
 ```bash
-npm install apollo-link-rest apollo-link graphql graphql-anywhere qs --save
+npm install apollo-link-rest apollo-link graphql qs --save
 or
-yarn add apollo-link-rest apollo-link graphql graphql-anywhere qs
+yarn add apollo-link-rest apollo-link graphql qs
 ```
 
-`apollo-link`, `graphql`, `qs` and `graphql-anywhere` are peer dependencies needed by `apollo-link-rest`.
+`apollo-link`, `graphql` and `qs` are peer dependencies needed by `apollo-link-rest`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ An Apollo Link to easily try out GraphQL without a full server. It can be used t
 ## Installation
 
 ```bash
-npm install apollo-link-rest apollo-link graphql qs --save
+npm install apollo-link-rest @apollo/client graphql qs --save
 or
-yarn add apollo-link-rest apollo-link graphql qs
+yarn add apollo-link-rest @apollo/client graphql qs
 ```
 
-`apollo-link`, `graphql`, and `qs` are peer dependencies needed by `apollo-link-rest`.
+`@apollo/client`, `graphql`, and `qs` are peer dependencies needed by `apollo-link-rest`.
 
 ## Usage
 

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -31,7 +31,7 @@ npm install --save apollo-cache-inmemory
 Then it is time to install our link and its `peerDependencies`:
 
 ```bash
-npm install --save apollo-link-rest apollo-link graphql graphql-anywhere qs
+npm install --save apollo-link-rest apollo-link graphql qs
 ```
 
 After this, you are ready to setup your apollo client:

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -25,7 +25,7 @@ npm install --save @apollo/client
 Then it is time to install our link and its `peerDependencies`:
 
 ```bash
-npm install --save apollo-link-rest apollo-link graphql qs
+npm install --save apollo-link-rest graphql qs
 ```
 
 After this, you are ready to setup your apollo client:

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -16,16 +16,10 @@ You can start using ApolloClient in your app today, let's see how!
 
 ## Quick start
 
-To get started, you need first to install apollo-client:
+To get started, you need first to install @apollo/client:
 
 ```bash
-npm install --save apollo-client
-```
-
-For an apollo client to work, you need a link and a cache, [more info here](https://www.apollographql.com/docs/react/basics/setup/#installation). Let's install the default in memory cache:
-
-```bash
-npm install --save apollo-cache-inmemory
+npm install --save @apollo/client
 ```
 
 Then it is time to install our link and its `peerDependencies`:
@@ -37,8 +31,7 @@ npm install --save apollo-link-rest apollo-link graphql qs
 After this, you are ready to setup your apollo client:
 
 ```js
-import { ApolloClient } from 'apollo-client';
-import { InMemoryCache } from 'apollo-cache-inmemory';
+import { ApolloClient, InMemoryCache } from '@apollo/client';
 import { RestLink } from 'apollo-link-rest';
 
 // setup your `RestLink` with your endpoint
@@ -50,6 +43,10 @@ const client = new ApolloClient({
   cache: new InMemoryCache(),
 });
 ```
+
+From the [Apollo Client "Get started" docs](https://www.apollographql.com/docs/react/get-started#step-3-initialize-apolloclient):
+
+> `cache` is an instance of `InMemoryCache`, which Apollo Client uses to cache query results after fetching them.
 
 Now it is time to write our first query, for this you need to install the `graphql-tag` package:
 

--- a/examples/advanced/package.json
+++ b/examples/advanced/package.json
@@ -7,7 +7,6 @@
     "apollo-client": "2.x",
     "apollo-link-rest": "0.x",
     "graphql": "0.x",
-    "graphql-anywhere": "4.x",
     "graphql-tag": "2.x",
     "qs": "^6.6.0",
     "react": "16.x",

--- a/examples/advanced/package.json
+++ b/examples/advanced/package.json
@@ -3,21 +3,31 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "apollo-cache-inmemory": "1.x",
-    "apollo-client": "2.x",
+    "@apollo/client": "3.7.1",
     "apollo-link-rest": "0.x",
-    "graphql": "0.x",
-    "graphql-tag": "2.x",
-    "qs": "^6.6.0",
-    "react": "16.x",
-    "react-apollo": "2.x",
-    "react-dom": "16.x",
-    "react-scripts": "1.x"
+    "graphql": "16.6.0",
+    "graphql-tag": "2.12.6",
+    "qs": "6.11.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-scripts": "5.0.1"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
   }
 }

--- a/examples/advanced/src/App.js
+++ b/examples/advanced/src/App.js
@@ -1,7 +1,5 @@
 import React, { Component } from 'react';
-import { ApolloClient } from 'apollo-client';
-import { InMemoryCache } from 'apollo-cache-inmemory';
-import { ApolloProvider } from 'react-apollo';
+import { ApolloClient, InMemoryCache, ApolloProvider } from '@apollo/client';
 import { RestLink } from 'apollo-link-rest';
 import SearchShow from './SearchShow';
 import './App.css';

--- a/examples/advanced/src/SearchShow.js
+++ b/examples/advanced/src/SearchShow.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { graphql } from 'react-apollo';
+import { graphql } from '@apollo/client/react/hoc';
 import gql from 'graphql-tag';
 
 const Season = ({ summary, number, image }) => (
@@ -27,7 +27,9 @@ const Query = gql`
 
 class ShowsResult extends Component {
   render() {
-    const { data: { loading, error, show } } = this.props;
+    const {
+      data: { loading, error, show },
+    } = this.props;
     if (loading) {
       return <h4>Loading...</h4>;
     }

--- a/examples/advanced/src/index.js
+++ b/examples/advanced/src/index.js
@@ -1,6 +1,8 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<App />);

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -7,7 +7,6 @@
     "apollo-client": "2.x",
     "apollo-link-rest": "0.x",
     "graphql": "0.x",
-    "graphql-anywhere": "4.x",
     "graphql-tag": "2.x",
     "qs": "^6.6.0",
     "react": "16.x",

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -3,21 +3,31 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "apollo-cache-inmemory": "1.x",
-    "apollo-client": "2.x",
+    "@apollo/client": "3.7.1",
     "apollo-link-rest": "0.x",
-    "graphql": "0.x",
-    "graphql-tag": "2.x",
-    "qs": "^6.6.0",
-    "react": "16.x",
-    "react-apollo": "2.x",
-    "react-dom": "16.x",
-    "react-scripts": "1.x"
+    "graphql": "16.6.0",
+    "graphql-tag": "2.12.6",
+    "qs": "6.11.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-scripts": "5.0.1"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
   }
 }

--- a/examples/simple/src/App.js
+++ b/examples/simple/src/App.js
@@ -1,7 +1,5 @@
 import React, { Component } from 'react';
-import { ApolloClient } from 'apollo-client';
-import { InMemoryCache } from 'apollo-cache-inmemory';
-import { ApolloProvider } from 'react-apollo';
+import { ApolloClient, InMemoryCache, ApolloProvider } from '@apollo/client';
 import { RestLink } from 'apollo-link-rest';
 import Person from './Person';
 import './App.css';

--- a/examples/simple/src/Person.js
+++ b/examples/simple/src/Person.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { graphql } from 'react-apollo';
+import { graphql } from '@apollo/client/react/hoc';
 import gql from 'graphql-tag';
 
 const Query = gql`

--- a/examples/simple/src/index.js
+++ b/examples/simple/src/index.js
@@ -1,6 +1,8 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<App />);

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -10,7 +10,6 @@
     "apollo-link": "1.x",
     "apollo-link-rest": "0.x",
     "graphql": "0.x",
-    "graphql-anywhere": "4.x",
     "graphql-tag": "2.x",
     "qs": "^6.6.0",
     "react": "16.x",

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -4,30 +4,38 @@
   "private": true,
   "main": "src/index.tsx",
   "dependencies": {
-    "@types/graphql": "0.x",
-    "apollo-cache-inmemory": "1.x",
-    "apollo-client": "2.x",
-    "apollo-link": "1.x",
+    "@apollo/client": "3.7.1",
     "apollo-link-rest": "0.x",
-    "graphql": "0.x",
-    "graphql-tag": "2.x",
-    "qs": "^6.6.0",
-    "react": "16.x",
-    "react-apollo": "2.x",
-    "react-dom": "16.x",
-    "react-scripts-ts": "2.x"
+    "graphql": "16.6.0",
+    "graphql-tag": "2.12.6",
+    "qs": "6.11.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-scripts": "5.0.1"
   },
   "scripts": {
-    "start": "react-scripts-ts start",
-    "build": "react-scripts-ts build",
-    "test": "react-scripts-ts test --env=jsdom",
-    "eject": "react-scripts-ts eject"
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --env=jsdom",
+    "eject": "react-scripts eject"
   },
   "devDependencies": {
-    "@types/jest": "23.x",
-    "@types/node": "10.x",
-    "@types/react": "16.x",
-    "@types/react-dom": "16.x",
-    "typescript": "2.9.x"
+    "@types/jest": "29.2.0",
+    "@types/node": "18.11.4",
+    "@types/react": "18.0.22",
+    "@types/react-dom": "18.0.7",
+    "typescript": "4.8.4"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
   }
 }

--- a/examples/typescript/src/Repo.tsx
+++ b/examples/typescript/src/Repo.tsx
@@ -60,10 +60,8 @@ const query = gql`
 // and inject the data into the component. The Result type is what
 // we expect the shape of the response to be and OwnProps is what we
 // expect to be passed to this component.
-const Repo = graphql<Result, OwnProps>(query, {
-  // @ts-ignore
+const Repo = graphql<OwnProps>(query, {
   options: ({ name }) => ({ variables: { name } }),
-  // @ts-ignore
 })(RepoBase);
 
 export { Repo };

--- a/examples/typescript/src/Repo.tsx
+++ b/examples/typescript/src/Repo.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { graphql, ChildProps } from 'react-apollo';
+import { graphql, ChildProps } from '@apollo/client/react/hoc';
 import gql from 'graphql-tag';
 
 // The Result type we expect back.
@@ -61,7 +61,9 @@ const query = gql`
 // we expect the shape of the response to be and OwnProps is what we
 // expect to be passed to this component.
 const Repo = graphql<Result, OwnProps>(query, {
+  // @ts-ignore
   options: ({ name }) => ({ variables: { name } }),
+  // @ts-ignore
 })(RepoBase);
 
 export { Repo };

--- a/examples/typescript/src/RepoSearch.tsx
+++ b/examples/typescript/src/RepoSearch.tsx
@@ -30,6 +30,7 @@ class RepoSearch extends React.Component<{}, State> {
           <option value="react-apollo">React Apollo</option>
           <option value="apollo-client">Apollo Client</option>
         </select>
+        {/* @ts-ignore */}
         <Repo name={this.state.repo} />
       </div>
     );

--- a/examples/typescript/src/RepoSearch.tsx
+++ b/examples/typescript/src/RepoSearch.tsx
@@ -30,7 +30,7 @@ class RepoSearch extends React.Component<{}, State> {
           <option value="react-apollo">React Apollo</option>
           <option value="apollo-client">Apollo Client</option>
         </select>
-        {/* @ts-ignore */}
+
         <Repo name={this.state.repo} />
       </div>
     );

--- a/examples/typescript/src/index.tsx
+++ b/examples/typescript/src/index.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
-import { render } from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { RestLink } from 'apollo-link-rest';
-import { ApolloClient } from 'apollo-client';
-import { InMemoryCache } from 'apollo-cache-inmemory';
-import { ApolloProvider } from 'react-apollo';
+import { ApolloClient, InMemoryCache, ApolloProvider } from '@apollo/client';
 
 import { RepoSearch } from './RepoSearch';
 
@@ -18,9 +16,11 @@ const client = new ApolloClient({
   link,
 });
 
-render(
+const container = document.getElementById('root')!;
+const root = createRoot(container);
+
+root.render(
   <ApolloProvider client={client}>
     <RepoSearch />
   </ApolloProvider>,
-  document.getElementById('root'),
 );

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "homepage": "https://github.com/apollographql/apollo-link-rest#readme",
   "scripts": {
-    "build:browser": "browserify ./lib/bundle.umd.js -o=./lib/bundle.js --i @apollo/client/core --i @apollo/client/utilities --i apollo-utilities --i graphql --i react && npm run minify:browser",
+    "build:browser": "browserify ./lib/bundle.umd.js -o=./lib/bundle.js --i @apollo/client/core --i @apollo/client/utilities --i graphql --i react && npm run minify:browser",
     "build": "tsc -p .",
     "bundle": "rollup -c",
     "clean": "rimraf lib/* coverage/* npm/*",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   "peerDependencies": {
     "@apollo/client": ">=3",
     "graphql": ">=0.11",
-    "graphql-anywhere": ">=4",
     "qs": ">=6"
   },
   "devDependencies": {
@@ -63,7 +62,6 @@
     "danger": "6.x",
     "fetch-mock": "7.x",
     "graphql": "14.x",
-    "graphql-anywhere": "4.1.x",
     "isomorphic-fetch": "2.2.x",
     "jest": "23.x",
     "jest-fetch-mock": "2.x",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,8 +5,6 @@ const globals = {
   '@apollo/client/core': 'apolloClient.core',
   '@apollo/client/utilities': 'apolloClient.utilities',
   '@apollo/link-error': 'apolloLink.error',
-  'graphql-anywhere': 'graphqlAnywhere',
-  'graphql-anywhere/lib/async': 'graphqlAnywhere.async',
 };
 
 export default {

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -28,11 +28,27 @@ import {
   checkDocument,
   removeDirectivesFromDocument,
 } from '@apollo/client/utilities';
-
-import { graphql } from 'graphql-anywhere/lib/async';
-import { Resolver, ExecInfo } from 'graphql-anywhere';
-
+import { graphql } from './utils/graphql';
 import * as qs from 'qs';
+
+export type DirectiveInfo = {
+  [fieldName: string]: { [argName: string]: any };
+};
+
+export type ExecInfo = {
+  isLeaf: boolean;
+  resultKey: string;
+  directives: DirectiveInfo;
+  field: FieldNode;
+};
+
+export type Resolver = (
+  fieldName: string,
+  rootValue: any,
+  args: any,
+  context: any,
+  info: ExecInfo,
+) => any;
 
 export namespace RestLink {
   export type URI = string;

--- a/src/utils/graphql.ts
+++ b/src/utils/graphql.ts
@@ -1,0 +1,264 @@
+/*
+  This file is a port of async.ts from the now-deprecated graphql-anywhere
+  package, which itself was based on the graphql fn from graphql-js.
+  Original source: https://github.com/apollographql/apollo-client/blob/release-2.x/packages/graphql-anywhere/src/async.ts
+
+  Utils that were previously imported from apollo-utilities can now be imported
+  from @apollo/client/utilities with the remaining types inlined in restLink.ts.
+*/
+
+import {
+  DocumentNode,
+  SelectionSetNode,
+  FieldNode,
+  FragmentDefinitionNode,
+  InlineFragmentNode,
+  DirectiveNode,
+} from 'graphql';
+
+import {
+  getMainDefinition,
+  getFragmentDefinitions,
+  createFragmentMap,
+  shouldInclude,
+  isField,
+  isInlineFragment,
+  resultKeyNameFromField,
+  argumentsObjectFromField,
+  FragmentMap,
+} from '@apollo/client/utilities';
+
+import { DirectiveInfo, ExecInfo, Resolver } from '../restLink';
+
+function getDirectiveInfoFromField(
+  field: FieldNode,
+  variables: Object,
+): DirectiveInfo {
+  if (field.directives && field.directives.length) {
+    const directiveObj: DirectiveInfo = {};
+    field.directives.forEach((directive: DirectiveNode) => {
+      directiveObj[directive.name.value] = argumentsObjectFromField(
+        directive,
+        variables,
+      );
+    });
+    return directiveObj;
+  }
+  return null;
+}
+
+type ResultMapper = (
+  values: { [fieldName: string]: any },
+  rootValue: any,
+) => any;
+
+type FragmentMatcher = (
+  rootValue: any,
+  typeCondition: string,
+  context: any,
+) => boolean;
+
+export type ExecContext = {
+  fragmentMap: FragmentMap;
+  contextValue: any;
+  variableValues: VariableMap;
+  resultMapper: ResultMapper;
+  resolver: Resolver;
+  fragmentMatcher: FragmentMatcher;
+};
+
+type ExecOptions = {
+  resultMapper?: ResultMapper;
+  fragmentMatcher?: FragmentMatcher;
+};
+
+const hasOwn = Object.prototype.hasOwnProperty;
+
+function merge(dest, src) {
+  if (src !== null && typeof src === 'object') {
+    Object.keys(src).forEach(key => {
+      const srcVal = src[key];
+      if (!hasOwn.call(dest, key)) {
+        dest[key] = srcVal;
+      } else {
+        merge(dest[key], srcVal);
+      }
+    });
+  }
+}
+
+type VariableMap = { [name: string]: any };
+
+/* Based on graphql function from graphql-js:
+ *
+ * graphql(
+ *   schema: GraphQLSchema,
+ *   requestString: string,
+ *   rootValue?: ?any,
+ *   contextValue?: ?any,
+ *   variableValues?: ?{[key: string]: any},
+ *   operationName?: ?string
+ * ): Promise<GraphQLResult>
+ *
+ */
+export function graphql(
+  resolver: Resolver,
+  document: DocumentNode,
+  rootValue?: any,
+  contextValue?: any,
+  variableValues?: VariableMap,
+  execOptions: ExecOptions = {},
+): Promise<null | Object> {
+  const mainDefinition = getMainDefinition(document);
+
+  const fragments = getFragmentDefinitions(document);
+  const fragmentMap = createFragmentMap(fragments);
+
+  const resultMapper = execOptions.resultMapper;
+
+  // Default matcher always matches all fragments
+  const fragmentMatcher = execOptions.fragmentMatcher || (() => true);
+
+  const execContext: ExecContext = {
+    fragmentMap,
+    contextValue,
+    variableValues,
+    resultMapper,
+    resolver,
+    fragmentMatcher,
+  };
+
+  return executeSelectionSet(
+    mainDefinition.selectionSet as SelectionSetNode,
+    rootValue,
+    execContext,
+  );
+}
+
+async function executeSelectionSet(
+  selectionSet: SelectionSetNode,
+  rootValue: any,
+  execContext: ExecContext,
+) {
+  const { fragmentMap, contextValue, variableValues: variables } = execContext;
+
+  const result = {};
+
+  const execute = async selection => {
+    if (!shouldInclude(selection, variables)) {
+      // Skip this entirely
+      return;
+    }
+
+    if (isField(selection)) {
+      const fieldResult = await executeField(
+        selection as FieldNode,
+        rootValue,
+        execContext,
+      );
+
+      const resultFieldKey = resultKeyNameFromField(selection);
+
+      if (fieldResult !== undefined) {
+        if (result[resultFieldKey] === undefined) {
+          result[resultFieldKey] = fieldResult;
+        } else {
+          merge(result[resultFieldKey], fieldResult);
+        }
+      }
+
+      return;
+    }
+
+    let fragment: InlineFragmentNode | FragmentDefinitionNode;
+
+    if (isInlineFragment(selection)) {
+      fragment = selection as InlineFragmentNode;
+    } else {
+      // This is a named fragment
+      fragment = fragmentMap[selection.name.value] as FragmentDefinitionNode;
+
+      if (!fragment) {
+        throw new Error(`No fragment named ${selection.name.value}`);
+      }
+    }
+
+    const typeCondition = fragment.typeCondition.name.value;
+
+    if (execContext.fragmentMatcher(rootValue, typeCondition, contextValue)) {
+      const fragmentResult = await executeSelectionSet(
+        fragment.selectionSet,
+        rootValue,
+        execContext,
+      );
+
+      merge(result, fragmentResult);
+    }
+  };
+
+  await Promise.all(selectionSet.selections.map(execute));
+
+  if (execContext.resultMapper) {
+    return execContext.resultMapper(result, rootValue);
+  }
+
+  return result;
+}
+
+async function executeField(
+  field: FieldNode,
+  rootValue: any,
+  execContext: ExecContext,
+): Promise<null | Object> {
+  const { variableValues: variables, contextValue, resolver } = execContext;
+
+  const fieldName = field.name.value;
+  const args = argumentsObjectFromField(field, variables);
+
+  const info: ExecInfo = {
+    isLeaf: !field.selectionSet,
+    resultKey: resultKeyNameFromField(field),
+    directives: getDirectiveInfoFromField(field, variables),
+    field,
+  };
+
+  const result = await resolver(fieldName, rootValue, args, contextValue, info);
+
+  // Handle all scalar types here
+  if (!field.selectionSet) {
+    return result;
+  }
+
+  // From here down, the field has a selection set, which means it's trying to
+  // query a GraphQLObjectType
+  if (result == null) {
+    // Basically any field in a GraphQL response can be null, or missing
+    return result;
+  }
+
+  if (Array.isArray(result)) {
+    return executeSubSelectedArray(field, result, execContext);
+  }
+
+  // Returned value is an object, and the query has a sub-selection. Recurse.
+  return executeSelectionSet(field.selectionSet, result, execContext);
+}
+
+function executeSubSelectedArray(field, result, execContext) {
+  return Promise.all(
+    result.map(item => {
+      // null value in array
+      if (item === null) {
+        return null;
+      }
+
+      // This is a nested array, recurse
+      if (Array.isArray(item)) {
+        return executeSubSelectedArray(field, item, execContext);
+      }
+
+      // This is an object, run the selection set on it
+      return executeSelectionSet(field.selectionSet, item, execContext);
+    }),
+  );
+}


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [ ] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

In light of the deprecation of `graphql-anywhere` in the course of releasing Apollo Client 3 in 2020, this PR inlines the `graphql` function previously imported from `graphql-anywhere/lib/async` as well as types `Resolver` and `ExecInfo` and removes all other references to the deprecated library.

NB: `graphql-anywhere@4.2.8` was published today with an [updated peer dependency range for the `graphql` package](https://github.com/apollographql/apollo-client/blob/release-2.x/packages/graphql-anywhere/package.json#L48-L50) to fix the `npm i` peer dependency error with `graphql@16` for npm7+ (https://github.com/apollographql/apollo-client/issues/10114), and to include a [deprecation notice](https://www.npmjs.com/package/graphql-anywhere).

Feel free to close this PR in favor of continuing with `graphql-anywhere` now that the peer dependency issue is resolved, but thought I'd open it in case it's useful :) Thanks!