### PR TITLE
Quick & dirty Apollo v4 compat

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,9 +9,9 @@ module.exports = {
       },
       diagnostics: {
         ignoreCodes: [
-          151001 // Suppress esModuleInterop suggestion that breaks __tests__/restLink.ts
-        ]
-      }
+          151001, // Suppress esModuleInterop suggestion that breaks __tests__/restLink.ts
+        ],
+      },
     },
   },
   transform: {
@@ -20,4 +20,5 @@ module.exports = {
   testRegex: '(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],
   setupFiles: ['./scripts/jest.js'],
+  testEnvironment: 'jsdom',
 };

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "module": "./lib/index.js",
   "jsnext:main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/apollographql/apollo-link-rest.git"
@@ -73,7 +74,7 @@
     "prettier": "1.15.x",
     "qs": "6.6.x",
     "rimraf": "2.6.x",
-    "rollup": "0.67.x",
+    "rollup": "^4.53.2",
     "rollup-plugin-local-resolve": "1.0.x",
     "rollup-plugin-sourcemaps": "0.4.x",
     "rxjs": "^7.8.2",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "fetch-mock": "7.x",
     "graphql": "16.x",
     "isomorphic-fetch": "2.2.x",
-    "jest": "23.x",
+    "jest": "29.x",
+    "jest-environment-jsdom": "^30.2.0",
     "jest-fetch-mock": "2.x",
     "lerna": "3.6.x",
     "lint-staged": "8.1.x",
@@ -77,7 +78,7 @@
     "rollup-plugin-sourcemaps": "0.4.x",
     "rxjs": "^7.8.2",
     "snake-case": "2.1.x",
-    "ts-jest": "23.10.x",
+    "ts-jest": "29.4.5",
     "typescript": "5.x",
     "uglify-js": "3.4.x"
   },

--- a/package.json
+++ b/package.json
@@ -49,11 +49,10 @@
     "qs": ">=6"
   },
   "devDependencies": {
-    "@apollo/client": "3.0.0-beta.29",
-    "@apollo/link-error": "^2.0.0-beta.3",
+    "@apollo/client": "4.0.9",
     "@babel/core": "7.x",
-    "@types/graphql": "14.x",
     "@types/jest": "23.x",
+    "@types/minimatch": "^3.0.5",
     "@types/node": "10.x",
     "@types/qs": "6.5.x",
     "browserify": "16.2.x",
@@ -62,7 +61,7 @@
     "codecov": "3.x",
     "danger": "6.x",
     "fetch-mock": "7.x",
-    "graphql": "14.x",
+    "graphql": "16.x",
     "isomorphic-fetch": "2.2.x",
     "jest": "23.x",
     "jest-fetch-mock": "2.x",
@@ -76,11 +75,11 @@
     "rollup": "0.67.x",
     "rollup-plugin-local-resolve": "1.0.x",
     "rollup-plugin-sourcemaps": "0.4.x",
+    "rxjs": "^7.8.2",
     "snake-case": "2.1.x",
     "ts-jest": "23.10.x",
     "typescript": "3.x",
-    "uglify-js": "3.4.x",
-    "@types/minimatch": "^3.0.5"
+    "uglify-js": "3.4.x"
   },
   "resolutions": {
     "babel-core": "7.0.0-bridge.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "rxjs": "^7.8.2",
     "snake-case": "2.1.x",
     "ts-jest": "23.10.x",
-    "typescript": "3.x",
+    "typescript": "5.x",
     "uglify-js": "3.4.x"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "qs": ">=6"
   },
   "devDependencies": {
-    "@apollo/client": "^3.0.0-beta.29",
+    "@apollo/client": "3.0.0-beta.29",
     "@apollo/link-error": "^2.0.0-beta.3",
     "@babel/core": "7.x",
     "@types/graphql": "14.x",
@@ -79,7 +79,8 @@
     "snake-case": "2.1.x",
     "ts-jest": "23.10.x",
     "typescript": "3.x",
-    "uglify-js": "3.4.x"
+    "uglify-js": "3.4.x",
+    "@types/minimatch": "^3.0.5"
   },
   "resolutions": {
     "babel-core": "7.0.0-bridge.0",

--- a/src/__tests__/restLink.ts
+++ b/src/__tests__/restLink.ts
@@ -1,28 +1,27 @@
 import {
   ApolloClient,
-  InMemoryCache,
   ApolloLink,
-  HttpLink,
-  execute,
-  from,
-  toPromise,
-  gql,
   disableFragmentWarnings,
-  ApolloQueryResult,
+  execute,
+  gql,
+  HttpLink,
+  InMemoryCache,
+  ServerError,
 } from '@apollo/client/core';
-import { onError } from '@apollo/link-error';
+import * as camelCase from 'camelcase';
+import * as fetchMock from 'fetch-mock';
+import {
+  normalizeHeaders,
+  RestLink,
+  validateRequestMethodForOperationType,
+} from '../restLink';
+import { firstValueFrom, map } from 'rxjs';
+import { OperationTypeNode } from 'graphql/language';
+import { ErrorLink } from '@apollo/client/link/error';
 
 disableFragmentWarnings();
 
-import * as camelCase from 'camelcase';
 const snake_case = require('snake-case');
-import * as fetchMock from 'fetch-mock';
-
-import {
-  RestLink,
-  validateRequestMethodForOperationType,
-  normalizeHeaders,
-} from '../restLink';
 
 /** Helper for extracting a simple object of headers from the HTTP-fetch Headers class */
 function flattenHeaders({
@@ -60,8 +59,13 @@ const sampleQuery = gql`
 
 type Result = { [index: string]: any };
 
-describe('Configuration', async () => {
-  describe('Errors', async () => {
+const dummyClient = new ApolloClient({
+  link: ApolloLink.empty(),
+  cache: new InMemoryCache(),
+});
+
+describe('Configuration', () => {
+  describe('Errors', () => {
     afterEach(() => {
       fetchMock.restore();
     });
@@ -104,11 +108,14 @@ describe('Configuration', async () => {
       `;
 
       try {
-        await toPromise<Result>(
-          execute(link, {
-            operationName: 'postTitle',
-            query: postTitleQuery,
-          }),
+        await firstValueFrom<Result>(
+          execute(
+            link,
+            {
+              query: postTitleQuery,
+            },
+            { client: dummyClient },
+          ),
         );
       } catch (error) {
         expect(error.message).toBe(
@@ -166,7 +173,7 @@ describe('Configuration', async () => {
     });
   });
 
-  describe('Field name normalizer', async () => {
+  describe('Field name normalizer', () => {
     afterEach(() => {
       fetchMock.restore();
     });
@@ -200,11 +207,14 @@ describe('Configuration', async () => {
         }
       `;
 
-      const { data } = await toPromise<Result>(
-        execute(link, {
-          operationName: 'postTitle',
-          query: postAndTags,
-        }),
+      const { data } = await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: postAndTags,
+          },
+          { client: dummyClient },
+        ),
       );
 
       expect(data.post.title).toBeDefined();
@@ -236,11 +246,14 @@ describe('Configuration', async () => {
         }
       `;
 
-      const { data } = await toPromise<Result>(
-        execute(link, {
-          operationName: 'postTitle',
-          query: postAndTags,
-        }),
+      const { data } = await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: postAndTags,
+          },
+          { client: dummyClient },
+        ),
       );
 
       expect(data.post.__typename).toBeDefined();
@@ -270,11 +283,14 @@ describe('Configuration', async () => {
         }
       `;
 
-      const { data } = await toPromise<Result>(
-        execute(link, {
-          operationName: 'postTitle',
-          query: postAndTags,
-        }),
+      const { data } = await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: postAndTags,
+          },
+          { client: dummyClient },
+        ),
       );
 
       expect(data.post.data).toBeDefined();
@@ -314,14 +330,17 @@ describe('Configuration', async () => {
         }
       `;
 
-      const { data } = await toPromise<Result>(
-        execute(link, {
-          operationName: 'postTitle',
-          query: postQuery,
-          variables: {
-            perRequestNormalizer: snake_case,
+      const { data } = await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: postQuery,
+            variables: {
+              perRequestNormalizer: snake_case,
+            },
           },
-        }),
+          { client: dummyClient },
+        ),
       );
 
       expect(data.post).toEqual({
@@ -357,11 +376,14 @@ describe('Configuration', async () => {
         }
       `;
 
-      const { data } = await toPromise<Result>(
-        execute(link, {
-          operationName: 'postTitle',
-          query: postTitle,
-        }),
+      const { data } = await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: postTitle,
+          },
+          { client: dummyClient },
+        ),
       );
 
       expect(data.post.title).toBe('custom');
@@ -591,11 +613,14 @@ describe('Complex responses need nested __typename insertions', () => {
       }
     `;
 
-    const { data } = await toPromise<Result>(
-      execute(link, {
-        operationName: 'someOperation',
-        query: someQuery,
-      }),
+    const { data } = await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: someQuery,
+        },
+        { client: dummyClient },
+      ),
     );
 
     expect(data).toMatchObject({
@@ -686,11 +711,14 @@ describe('Complex responses need nested __typename insertions', () => {
       }
     `;
 
-    const { data } = await toPromise<Result>(
-      execute(link, {
-        operationName: 'someOperation',
-        query: someQuery,
-      }),
+    const { data } = await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: someQuery,
+        },
+        { client: dummyClient },
+      ),
     );
 
     expect(data).toMatchObject({
@@ -924,11 +952,14 @@ describe('Complex responses need nested __typename insertions', () => {
       }
     `;
 
-    const { data } = await toPromise<Result>(
-      execute(link, {
-        operationName: 'someOperation',
-        query: someQuery,
-      }),
+    const { data } = await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: someQuery,
+        },
+        { client: dummyClient },
+      ),
     );
 
     expect(data).toMatchObject({
@@ -970,8 +1001,8 @@ describe('Can customize/parse the response before passing to Apollo', () => {
           }
         }
       `;
-      const { data: restData } = await toPromise<Result>(
-        execute(link, { operationName: 'restQuery', query: restQuery }),
+      const { data: restData } = await firstValueFrom<Result>(
+        execute(link, { query: restQuery }, { client: dummyClient }),
       );
       expect(restData).toEqual({
         post: {
@@ -1003,8 +1034,8 @@ describe('Can customize/parse the response before passing to Apollo', () => {
           }
         }
       `;
-      const { data: restData } = await toPromise<Result>(
-        execute(link, { operationName: 'restQuery', query: restQuery }),
+      const { data: restData } = await firstValueFrom<Result>(
+        execute(link, { query: restQuery }, { client: dummyClient }),
       );
       expect(restData).toEqual({
         posts: [
@@ -1016,7 +1047,7 @@ describe('Can customize/parse the response before passing to Apollo', () => {
   });
 
   describe('with endpoint level `responseTransformer`', () => {
-    it('handles single record responses', async done => {
+    it('handles single record responses', async () => {
       fetchMock.get('/api/v1/posts/1', {
         meta: {},
         post: posts[1],
@@ -1024,8 +1055,9 @@ describe('Can customize/parse the response before passing to Apollo', () => {
 
       const link = new RestLink({
         // This is purpsefully wrong so that we verify the endpoint one is called
-        responseTransformer: () =>
-          done.fail('Should have called endpoint.responseTransformer'),
+        responseTransformer: () => {
+          throw new Error('Should have called endpoint.responseTransformer');
+        },
         endpoints: {
           v1: {
             uri: '/api/v1',
@@ -1045,8 +1077,8 @@ describe('Can customize/parse the response before passing to Apollo', () => {
           }
         }
       `;
-      const { data: restData } = await toPromise<Result>(
-        execute(link, { operationName: 'restQuery', query: restQuery }),
+      const { data: restData } = await firstValueFrom<Result>(
+        execute(link, { query: restQuery }, { client: dummyClient }),
       );
       expect(restData).toEqual({
         post: {
@@ -1055,18 +1087,18 @@ describe('Can customize/parse the response before passing to Apollo', () => {
           __typename: 'Post',
         },
       });
-      done();
     });
 
-    it('handles multiple record responses', async done => {
+    it('handles multiple record responses', async () => {
       fetchMock.get('/api/v1/posts', {
         meta: {},
         posts,
       });
 
       const link = new RestLink({
-        responseTransformer: () =>
-          done.fail('Should have called endpoint.responseTransformer'),
+        responseTransformer: () => {
+          throw new Error('Should have called endpoint.responseTransformer');
+        },
         endpoints: {
           v1: {
             uri: '/api/v1',
@@ -1085,8 +1117,8 @@ describe('Can customize/parse the response before passing to Apollo', () => {
           }
         }
       `;
-      const { data: restData } = await toPromise<Result>(
-        execute(link, { operationName: 'restQuery', query: restQuery }),
+      const { data: restData } = await firstValueFrom<Result>(
+        execute(link, { query: restQuery }, { client: dummyClient }),
       );
       expect(restData).toEqual({
         posts: [
@@ -1094,7 +1126,6 @@ describe('Can customize/parse the response before passing to Apollo', () => {
           { title: 'Respect apollo', __typename: 'Post' },
         ],
       });
-      done();
     });
   });
 });
@@ -1120,11 +1151,14 @@ describe('Query single call', () => {
       }
     `;
 
-    const { data } = await toPromise<Result>(
-      execute(link, {
-        operationName: 'postTitle',
-        query: postTitleQuery,
-      }),
+    const { data } = await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: postTitleQuery,
+        },
+        { client: dummyClient },
+      ),
     );
 
     expect(data).toMatchObject({ post: { ...post, __typename: 'Post' } });
@@ -1142,11 +1176,14 @@ describe('Query single call', () => {
       }
     `;
 
-    const { data } = await toPromise<Result>(
-      execute(link, {
-        operationName: 'serverConfig',
-        query: serverConfigQuery,
-      }),
+    const { data } = await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: serverConfigQuery,
+        },
+        { client: dummyClient },
+      ),
     );
 
     expect(data).toMatchObject({ config: stringResp });
@@ -1164,11 +1201,14 @@ describe('Query single call', () => {
         admins @rest(type: "[String!]!", path: "/admins")
       }
     `;
-    const { data } = await toPromise<Result>(
-      execute(link, {
-        operationName: 'adminIds',
-        query: adminsQuery,
-      }),
+    const { data } = await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: adminsQuery,
+        },
+        { client: dummyClient },
+      ),
     );
 
     expect(data).toMatchObject({ admins: arrayResp });
@@ -1190,11 +1230,14 @@ describe('Query single call', () => {
       }
     `;
 
-    const { data } = await toPromise<Result>(
-      execute(link, {
-        operationName: 'postTitle',
-        query: postTitleQuery,
-      }),
+    const { data } = await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: postTitleQuery,
+        },
+        { client: dummyClient },
+      ),
     );
 
     expect(data).toMatchObject({ post });
@@ -1230,11 +1273,14 @@ describe('Query single call', () => {
       }
     `;
 
-    const { data } = await toPromise<Result>(
-      execute(link, {
-        operationName: 'tags',
-        query: tagsQuery,
-      }),
+    const { data } = await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: tagsQuery,
+        },
+        { client: dummyClient },
+      ),
     );
 
     const tagsWithTypeName = tags.map(tag => ({
@@ -1271,11 +1317,14 @@ describe('Query single call', () => {
       }
     `;
 
-    const { data } = await toPromise<Result>(
-      execute(link, {
-        operationName: 'postWithContent',
-        query: postTitleQuery,
-      }),
+    const { data } = await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: postTitleQuery,
+        },
+        { client: dummyClient },
+      ),
     );
 
     expect(data.post.content).toBeUndefined();
@@ -1297,11 +1346,14 @@ describe('Query single call', () => {
       }
     `;
 
-    const { data } = await toPromise<Result>(
-      execute(link, {
-        operationName: 'postTitle',
-        query: postTitleQuery,
-      }),
+    const { data } = await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: postTitleQuery,
+        },
+        { client: dummyClient },
+      ),
     );
 
     expect(data).toMatchObject({ post: { ...post, __typename: 'Post' } });
@@ -1324,12 +1376,15 @@ describe('Query single call', () => {
       }
     `;
 
-    const { data } = await toPromise<Result>(
-      execute(link, {
-        operationName: 'postTitle',
-        query: postTitleQuery,
-        variables: { id: '1' },
-      }),
+    const { data } = await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: postTitleQuery,
+          variables: { id: '1' },
+        },
+        { client: dummyClient },
+      ),
     );
 
     expect(data.post.title).toBe(post.title);
@@ -1353,12 +1408,15 @@ describe('Query single call', () => {
       }
     `;
 
-    const { data } = await toPromise<Result>(
-      execute(link, {
-        operationName: 'feed',
-        query: feedQuery,
-        variables: { offset: 0 },
-      }),
+    const { data } = await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: feedQuery,
+          variables: { offset: 0 },
+        },
+        { client: dummyClient },
+      ),
     );
 
     expect(data.post.title).toBe(post.title);
@@ -1382,12 +1440,15 @@ describe('Query single call', () => {
       }
     `;
 
-    const { data } = await toPromise<Result>(
-      execute(link, {
-        operationName: 'feed',
-        query: feedQuery,
-        variables: { published: false },
-      }),
+    const { data } = await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: feedQuery,
+          variables: { published: false },
+        },
+        { client: dummyClient },
+      ),
     );
 
     expect(data.post.title).toBe(post.title);
@@ -1410,12 +1471,15 @@ describe('Query single call', () => {
       }
     `;
 
-    const { data } = await toPromise<Result>(
-      execute(link, {
-        operationName: 'feed',
-        query: peopleWithoutAddressQuery,
-        variables: { address: null },
-      }),
+    const { data } = await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: peopleWithoutAddressQuery,
+          variables: { address: null },
+        },
+        { client: dummyClient },
+      ),
     );
 
     expect(data.people.name).toBe(person.name);
@@ -1448,19 +1512,25 @@ describe('Query single call', () => {
       }
     `;
 
-    const { data: data1 } = await toPromise<Result>(
-      execute(link, {
-        operationName: 'postTitle1',
-        query: postTitleQuery1,
-        variables: { id: '1' },
-      }),
+    const { data: data1 } = await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: postTitleQuery1,
+          variables: { id: '1' },
+        },
+        { client: dummyClient },
+      ),
     );
-    const { data: data2 } = await toPromise<Result>(
-      execute(link, {
-        operationName: 'postTitle2',
-        query: postTitleQuery2,
-        variables: { id: '1' },
-      }),
+    const { data: data2 } = await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: postTitleQuery2,
+          variables: { id: '1' },
+        },
+        { client: dummyClient },
+      ),
     );
 
     expect(data1.post.title).toBe(postV1.title);
@@ -1501,11 +1571,14 @@ describe('Query single call', () => {
       }
     `;
 
-    const { data } = await toPromise<Result>(
-      execute(link, {
-        operationName: 'postTitle',
-        query: postTitleQuery,
-      }),
+    const { data } = await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: postTitleQuery,
+        },
+        { client: dummyClient },
+      ),
     );
 
     expect(data).toMatchObject({
@@ -1532,11 +1605,14 @@ describe('Query single call', () => {
       }
     `;
 
-    const { data } = await toPromise<Result>(
-      execute(link, {
-        operationName: 'noContent',
-        query: queryWithNoContent,
-      }),
+    const { data } = await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: queryWithNoContent,
+        },
+        { client: dummyClient },
+      ),
     );
 
     expect(data).toMatchObject({
@@ -1567,11 +1643,14 @@ describe('Query single call', () => {
     `;
 
     try {
-      await toPromise<Result>(
-        execute(link, {
-          operationName: 'noContent',
-          query: errorWithNoContent,
-        }),
+      await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: errorWithNoContent,
+          },
+          { client: dummyClient },
+        ),
       );
     } catch (e) {
       expect(e).toEqual(
@@ -1632,15 +1711,18 @@ describe('Use a custom pathBuilder', () => {
       return '/posts' + qs;
     }
 
-    const { data: data1 } = await toPromise<Result>(
-      execute(link, {
-        operationName: 'postTitle',
-        query: postTitleQuery,
-        variables: {
-          status: 'published',
-          pathFunction: createPostsPath,
+    const { data: data1 } = await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: postTitleQuery,
+          variables: {
+            status: 'published',
+            pathFunction: createPostsPath,
+          },
         },
-      }),
+        { client: dummyClient },
+      ),
     );
 
     expect(data1).toMatchObject({
@@ -1648,15 +1730,18 @@ describe('Use a custom pathBuilder', () => {
     });
 
     // Extra tests below to disprove: https://github.com/apollographql/apollo-link-rest/issues/102
-    const { data: data2 } = await toPromise<Result>(
-      execute(link, {
-        operationName: 'postTitle',
-        query: postTitleQuery,
-        variables: {
-          otherStatus: 'published',
-          pathFunction: createPostsPath,
+    const { data: data2 } = await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: postTitleQuery,
+          variables: {
+            otherStatus: 'published',
+            pathFunction: createPostsPath,
+          },
         },
-      }),
+        { client: dummyClient },
+      ),
     );
 
     expect(data2).toMatchObject({
@@ -1668,7 +1753,7 @@ describe('Use a custom pathBuilder', () => {
       link,
     });
 
-    const { data: data1b }: ApolloQueryResult<any> = await client.query({
+    const { data: data1b }: ApolloLink.Result<any> = await client.query({
       query: postTitleQuery,
       variables: {
         status: 'published',
@@ -1679,7 +1764,7 @@ describe('Use a custom pathBuilder', () => {
       posts: [{ ...posts1[0], __typename: 'Post' }],
     });
 
-    const { data: data2b }: ApolloQueryResult<any> = await client.query({
+    const { data: data2b }: ApolloLink.Result<any> = await client.query({
       query: postTitleQuery,
       variables: {
         otherStatus: 'published',
@@ -1733,32 +1818,41 @@ describe('Use a custom pathBuilder', () => {
       }
     `;
 
-    await toPromise<Result>(
-      execute(link, {
-        operationName: 'postQuery',
-        query: nonEncodedQuery,
-        variables: { name: 'Love apollo' },
-      }),
+    await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: nonEncodedQuery,
+          variables: { name: 'Love apollo' },
+        },
+        { client: dummyClient },
+      ),
     );
 
     expect(fetchMock.called('/api/posts?name=Love apollo')).toBe(true);
 
-    await toPromise<Result>(
-      execute(link, {
-        operationName: 'postQuery',
-        query: encodedQuery,
-        variables: { name: 'Love apollo' },
-      }),
+    await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: encodedQuery,
+          variables: { name: 'Love apollo' },
+        },
+        { client: dummyClient },
+      ),
     );
 
     expect(fetchMock.called('/api/posts?name=Love%20apollo')).toBe(true);
 
-    await toPromise<Result>(
-      execute(link, {
-        operationName: 'postQuery',
-        query: mixedQuery,
-        variables: { id: 1, query: { comments: 5 } },
-      }),
+    await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: mixedQuery,
+          variables: { id: 1, query: { comments: 5 } },
+        },
+        { client: dummyClient },
+      ),
     );
 
     expect(fetchMock.called('/api/posts/1?comments=5')).toBe(true);
@@ -1796,11 +1890,14 @@ describe('Query multiple calls', () => {
       }
     `;
 
-    const { data } = await toPromise<Result>(
-      execute(link, {
-        operationName: 'postAndTags',
-        query: postAndTags,
-      }),
+    const { data } = await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: postAndTags,
+        },
+        { client: dummyClient },
+      ),
     );
 
     expect(data.post).toBeDefined();
@@ -1831,11 +1928,14 @@ describe('Query multiple calls', () => {
       }
     `;
 
-    const { data } = await toPromise<Result>(
-      execute(link, {
-        operationName: 'postAndTags',
-        query: postAndTags,
-      }),
+    const { data } = await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: postAndTags,
+        },
+        { client: dummyClient },
+      ),
     );
 
     expect(data.post).toBeDefined();
@@ -1867,11 +1967,14 @@ describe('Query multiple calls', () => {
       }
     `;
 
-    const { data } = await toPromise<Result>(
-      execute(link, {
-        operationName: 'postAndTags',
-        query: postAndTags,
-      }),
+    const { data } = await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: postAndTags,
+        },
+        { client: dummyClient },
+      ),
     );
 
     expect(data.tags).toBeDefined();
@@ -1879,7 +1982,7 @@ describe('Query multiple calls', () => {
   });
 });
 
-describe('GraphQL aliases should work', async () => {
+describe('GraphQL aliases should work', () => {
   afterEach(() => {
     fetchMock.restore();
   });
@@ -1909,12 +2012,15 @@ describe('GraphQL aliases should work', async () => {
       }
     `;
 
-    const { data } = await toPromise<Result>(
-      execute(link, {
-        operationName: 'postTitle',
-        query: postTitleQueries,
-        variables: { id: '1' },
-      }),
+    const { data } = await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: postTitleQueries,
+          variables: { id: '1' },
+        },
+        { client: dummyClient },
+      ),
     );
 
     expect(data.v1.title).toBe(postV1.title);
@@ -1938,12 +2044,15 @@ describe('GraphQL aliases should work', async () => {
       }
     `;
 
-    const { data } = await toPromise<Result>(
-      execute(link, {
-        operationName: 'postTitle',
-        query: postTitleQueries,
-        variables: { id: '1' },
-      }),
+    const { data } = await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: postTitleQueries,
+          variables: { id: '1' },
+        },
+        { client: dummyClient },
+      ),
     );
 
     expect(data.post.title).toBe(postV1.titleText);
@@ -1968,11 +2077,14 @@ describe('Query options', () => {
       const post = { id: '1', Title: 'Love apollo' };
       fetchMock.get('/api/post/1', post);
 
-      await toPromise<Result>(
-        execute(link, {
-          operationName: 'post',
-          query: sampleQuery,
-        }),
+      await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: sampleQuery,
+          },
+          { client: dummyClient },
+        ),
       );
 
       const credentials = fetchMock.lastCall()[1].credentials;
@@ -1986,11 +2098,13 @@ describe('Query options', () => {
         operation.setContext({
           credentials: 'my-credentials',
         });
-        return forward(operation).map(result => {
-          const { credentials } = operation.getContext();
-          expect(credentials).toBeDefined();
-          return result;
-        });
+        return forward(operation).pipe(
+          map(result => {
+            const { credentials } = operation.getContext();
+            expect(credentials).toBeDefined();
+            return result;
+          }),
+        );
       });
 
       const link = ApolloLink.from([
@@ -2001,11 +2115,14 @@ describe('Query options', () => {
       const post = { id: '1', title: 'Love apollo' };
       fetchMock.get('/api/post/1', post);
 
-      await toPromise<Result>(
-        execute(link, {
-          operationName: 'post',
-          query: sampleQuery,
-        }),
+      await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: sampleQuery,
+          },
+          { client: dummyClient },
+        ),
       );
 
       const credentials = fetchMock.lastCall()[1].credentials;
@@ -2019,11 +2136,13 @@ describe('Query options', () => {
         operation.setContext({
           credentials: 'my-credentials',
         });
-        return forward(operation).map(result => {
-          const { credentials } = operation.getContext();
-          expect(credentials).toBeDefined();
-          return result;
-        });
+        return forward(operation).pipe(
+          map(result => {
+            const { credentials } = operation.getContext();
+            expect(credentials).toBeDefined();
+            return result;
+          }),
+        );
       });
 
       const link = ApolloLink.from([
@@ -2037,11 +2156,14 @@ describe('Query options', () => {
       const post = { id: '1', title: 'Love apollo' };
       fetchMock.get('/api/post/1', post);
 
-      await toPromise<Result>(
-        execute(link, {
-          operationName: 'post',
-          query: sampleQuery,
-        }),
+      await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: sampleQuery,
+          },
+          { client: dummyClient },
+        ),
       );
 
       const credentials = fetchMock.lastCall()[1].credentials;
@@ -2052,15 +2174,17 @@ describe('Query options', () => {
       expect.assertions(5);
 
       const credentialsMiddleware = new ApolloLink((operation, forward) => {
-        return forward(operation).map(result => {
-          const { restResponses } = operation.getContext();
-          expect(restResponses).toHaveLength(2);
-          expect(restResponses[0].url).toBe('/api/post/1');
-          expect(restResponses[0].headers.get('Header1')).toBe('Header1');
-          expect(restResponses[1].url).toBe('/api/tags');
-          expect(restResponses[1].headers.get('Header2')).toBe('Header2');
-          return result;
-        });
+        return forward(operation).pipe(
+          map(result => {
+            const { restResponses } = operation.getContext();
+            expect(restResponses).toHaveLength(2);
+            expect(restResponses[0].url).toBe('/api/post/1');
+            expect(restResponses[0].headers.get('Header1')).toBe('Header1');
+            expect(restResponses[1].url).toBe('/api/tags');
+            expect(restResponses[1].headers.get('Header2')).toBe('Header2');
+            return result;
+          }),
+        );
       });
 
       const link = ApolloLink.from([
@@ -2094,12 +2218,15 @@ describe('Query options', () => {
         }
       `;
 
-      await toPromise<Result>(
-        execute(link, {
-          operationName: 'postAndTags',
-          query: postAndTags,
-          context,
-        }),
+      await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: postAndTags,
+            context,
+          },
+          { client: dummyClient },
+        ),
       );
     });
   });
@@ -2121,12 +2248,15 @@ describe('Query options', () => {
         }
       `;
 
-      await toPromise<Result>(
-        execute(link, {
-          operationName: 'postTitle',
-          query: postTitleQuery,
-          variables: { id: '1' },
-        }),
+      await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: postTitleQuery,
+            variables: { id: '1' },
+          },
+          { client: dummyClient },
+        ),
       );
 
       const requestCall = fetchMock.calls('/api/post/1')[0];
@@ -2152,12 +2282,15 @@ describe('Query options', () => {
         }
       `;
 
-      await toPromise<Result>(
-        execute(link, {
-          operationName: 'postTitle',
-          query: postTitleQuery,
-          variables: { id: '1' },
-        }),
+      await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: postTitleQuery,
+            variables: { id: '1' },
+          },
+          { client: dummyClient },
+        ),
       );
 
       const requestCall = fetchMock.calls('/api/post/1')[0];
@@ -2185,7 +2318,9 @@ describe('Query options', () => {
       };
 
       const link1 = new RestLink({ uri: '/api' });
-      await toPromise<Result>(execute(link1, operation));
+      await firstValueFrom<Result>(
+        execute(link1, operation, { client: dummyClient }),
+      );
 
       const link2 = new RestLink({
         uri: '/api',
@@ -2193,7 +2328,9 @@ describe('Query options', () => {
           Accept: 'text/plain',
         },
       });
-      await toPromise<Result>(execute(link2, operation));
+      await firstValueFrom<Result>(
+        execute(link2, operation, { client: dummyClient }),
+      );
 
       const requestCalls = fetchMock.calls('/api/posts');
       expect(orderDupPreservingFlattenedHeaders(requestCalls[0][1])).toEqual([
@@ -2210,11 +2347,13 @@ describe('Query options', () => {
         operation.setContext({
           headers: { authorization: '1234' },
         });
-        return forward(operation).map(result => {
-          const { headers } = operation.getContext();
-          expect(headers).toBeDefined();
-          return result;
-        });
+        return forward(operation).pipe(
+          map(result => {
+            const { headers } = operation.getContext();
+            expect(headers).toBeDefined();
+            return result;
+          }),
+        );
       });
       const link = ApolloLink.from([
         headersMiddleware,
@@ -2233,12 +2372,15 @@ describe('Query options', () => {
         }
       `;
 
-      await toPromise<Result>(
-        execute(link, {
-          operationName: 'postTitle',
-          query: postTitleQuery,
-          variables: { id: '1' },
-        }),
+      await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: postTitleQuery,
+            variables: { id: '1' },
+          },
+          { client: dummyClient },
+        ),
       );
 
       const requestCall = fetchMock.calls('/api/post/1')[0];
@@ -2265,12 +2407,15 @@ describe('Query options', () => {
         }
       `;
 
-      await toPromise<Result>(
-        execute(link, {
-          operationName: 'postTitle',
-          query: postTitleQuery,
-          variables: { id: '1' },
-        }),
+      await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: postTitleQuery,
+            variables: { id: '1' },
+          },
+          { client: dummyClient },
+        ),
       );
 
       const requestCall = fetchMock.calls('/api/post/1')[0];
@@ -2295,11 +2440,13 @@ describe('Query options', () => {
           },
           headersToOverride: ['authorization'],
         });
-        return forward(operation).map(result => {
-          const { headers } = operation.getContext();
-          expect(headers).toBeDefined();
-          return result;
-        });
+        return forward(operation).pipe(
+          map(result => {
+            const { headers } = operation.getContext();
+            expect(headers).toBeDefined();
+            return result;
+          }),
+        );
       });
       const link = ApolloLink.from([
         headersMiddleware,
@@ -2321,12 +2468,15 @@ describe('Query options', () => {
         }
       `;
 
-      await toPromise<Result>(
-        execute(link, {
-          operationName: 'postTitle',
-          query: postTitleQuery,
-          variables: { id: '1' },
-        }),
+      await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: postTitleQuery,
+            variables: { id: '1' },
+          },
+          { client: dummyClient },
+        ),
       );
 
       const requestCall = fetchMock.calls('/api/post/1')[0];
@@ -2358,11 +2508,13 @@ describe('Query options', () => {
           headers: { authorization: 'context', context: 'context' },
           headersMergePolicy,
         });
-        return forward(operation).map(result => {
-          const { headers } = operation.getContext();
-          expect(headers).toBeDefined();
-          return result;
-        });
+        return forward(operation).pipe(
+          map(result => {
+            const { headers } = operation.getContext();
+            expect(headers).toBeDefined();
+            return result;
+          }),
+        );
       });
       const link = ApolloLink.from([
         headersMiddleware,
@@ -2384,12 +2536,15 @@ describe('Query options', () => {
         }
       `;
 
-      await toPromise<Result>(
-        execute(link, {
-          operationName: 'postTitle',
-          query: postTitleQuery,
-          variables: { id: '1' },
-        }),
+      await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: postTitleQuery,
+            variables: { id: '1' },
+          },
+          { client: dummyClient },
+        ),
       );
 
       const requestCall = fetchMock.calls('/api/post/1')[0];
@@ -2410,11 +2565,13 @@ describe('Query options', () => {
         operation.setContext({
           headers: { authorization: 'context' },
         });
-        return forward(operation).map(result => {
-          const { headers } = operation.getContext();
-          expect(headers).toBeDefined();
-          return result;
-        });
+        return forward(operation).pipe(
+          map(result => {
+            const { headers } = operation.getContext();
+            expect(headers).toBeDefined();
+            return result;
+          }),
+        );
       });
       const link = ApolloLink.from([
         headersMiddleware,
@@ -2436,12 +2593,15 @@ describe('Query options', () => {
         }
       `;
 
-      await toPromise<Result>(
-        execute(link, {
-          operationName: 'postTitle',
-          query: postTitleQuery,
-          variables: { id: '1' },
-        }),
+      await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: postTitleQuery,
+            variables: { id: '1' },
+          },
+          { client: dummyClient },
+        ),
       );
 
       const requestCall = fetchMock.calls('/api/post/1')[0];
@@ -2460,11 +2620,13 @@ describe('Query options', () => {
         operation.setContext({
           headers: undefined,
         });
-        return forward(operation).map(result => {
-          const { headers } = operation.getContext();
-          expect(headers).toBeUndefined();
-          return result;
-        });
+        return forward(operation).pipe(
+          map(result => {
+            const { headers } = operation.getContext();
+            expect(headers).toBeUndefined();
+            return result;
+          }),
+        );
       });
       const link = ApolloLink.from([
         headersMiddleware,
@@ -2483,12 +2645,15 @@ describe('Query options', () => {
         }
       `;
 
-      await toPromise<Result>(
-        execute(link, {
-          operationName: 'postTitle',
-          query: postTitleQuery,
-          variables: { id: '1' },
-        }),
+      await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: postTitleQuery,
+            variables: { id: '1' },
+          },
+          { client: dummyClient },
+        ),
       );
 
       const requestCall = fetchMock.calls('/api/post/1')[0];
@@ -2527,12 +2692,15 @@ describe('Mutation', () => {
           }
         }
       `;
-      const response = await toPromise<Result>(
-        execute(link, {
-          operationName: 'publishPost',
-          query: createPostMutation,
-          variables: { input: { title: post.title } },
-        }),
+      const response = await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: createPostMutation,
+            variables: { input: { title: post.title } },
+          },
+          { client: dummyClient },
+        ),
       );
       expect(response.data.publishedPost).toEqual(resultPost);
 
@@ -2565,12 +2733,15 @@ describe('Mutation', () => {
           }
         }
       `;
-      const response = await toPromise<Result>(
-        execute(link, {
-          operationName: 'republish',
-          query: replacePostMutation,
-          variables: { id: post.id, input: post },
-        }),
+      const response = await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: replacePostMutation,
+            variables: { id: post.id, input: post },
+          },
+          { client: dummyClient },
+        ),
       );
       expect(response.data.replacedPost).toEqual(resultPost);
 
@@ -2605,12 +2776,15 @@ describe('Mutation', () => {
           }
         }
       `;
-      const response = await toPromise<Result>(
-        execute(link, {
-          operationName: 'editPost',
-          query: editPostMutation,
-          variables: { id: post.id, input: { categoryId: post.categoryId } },
-        }),
+      const response = await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: editPostMutation,
+            variables: { id: post.id, input: { categoryId: post.categoryId } },
+          },
+          { client: dummyClient },
+        ),
       );
       expect(response.data.editedPost).toEqual(resultPost);
 
@@ -2636,12 +2810,15 @@ describe('Mutation', () => {
           }
         }
       `;
-      await toPromise<Result>(
-        execute(link, {
-          operationName: 'deletePost',
-          query: replacePostMutation,
-          variables: { id: post.id },
-        }),
+      await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: replacePostMutation,
+            variables: { id: post.id },
+          },
+          { client: dummyClient },
+        ),
       );
 
       const requestCall = fetchMock.calls('/api/posts/1')[0];
@@ -2682,12 +2859,15 @@ describe('Mutation', () => {
           }
         }
       `;
-      const response = await toPromise<Result>(
-        execute(link, {
-          operationName: 'publishPost',
-          query: createPostMutation,
-          variables: { input: { title: post.title } },
-        }),
+      const response = await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: createPostMutation,
+            variables: { input: { title: post.title } },
+          },
+          { client: dummyClient },
+        ),
       );
 
       expect(response.data.publishedPost).toEqual({
@@ -2724,12 +2904,15 @@ describe('Mutation', () => {
         }
       `;
 
-      const response = await toPromise<Result>(
-        execute(link, {
-          operationName: 'publishPost',
-          query: createPostMutation,
-          variables: { input: { title: post.title } },
-        }),
+      const response = await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: createPostMutation,
+            variables: { input: { title: post.title } },
+          },
+          { client: dummyClient },
+        ),
       );
 
       expect(response.data.publishedPost).toEqual({
@@ -2763,12 +2946,15 @@ describe('Mutation', () => {
       `;
 
       try {
-        await toPromise<Result>(
-          execute(link, {
-            operationName: 'publishPost',
-            query: createPostMutation,
-            variables: { input: { title: null } },
-          }),
+        await firstValueFrom<Result>(
+          execute(
+            link,
+            {
+              query: createPostMutation,
+              variables: { input: { title: null } },
+            },
+            { client: dummyClient },
+          ),
         );
       } catch (e) {
         expect(e).toEqual(
@@ -2803,12 +2989,15 @@ describe('Mutation', () => {
         }
       }
     `;
-    return await toPromise<Result>(
-      execute(link, {
-        operationName: 'publishPost',
-        query: createPostMutation,
-        variables: { input: { title: post.title } },
-      }),
+    return await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: createPostMutation,
+          variables: { input: { title: post.title } },
+        },
+        { client: dummyClient },
+      ),
     ).catch(e =>
       expect(e).toEqual(
         new Error('Response not successful: Received status code 500'),
@@ -2851,12 +3040,15 @@ describe('Mutation', () => {
           }
         }
       `;
-      const response = await toPromise<Result>(
-        execute(link, {
-          operationName: 'publishPost',
-          query: createPostMutation,
-          variables: { input: camelPost },
-        }),
+      const response = await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: createPostMutation,
+            variables: { input: camelPost },
+          },
+          { client: dummyClient },
+        ),
       );
 
       const requestCall = fetchMock.calls('/api/posts/new')[0];
@@ -2907,12 +3099,18 @@ describe('Mutation', () => {
           }
         }
       `;
-      const response = await toPromise<Result>(
-        execute(link, {
-          operationName: 'publishPost',
-          query: createPostMutation,
-          variables: { input: camelPost, requestLevelDenormalizer: snake_case },
-        }),
+      const response = await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: createPostMutation,
+            variables: {
+              input: camelPost,
+              requestLevelDenormalizer: snake_case,
+            },
+          },
+          { client: dummyClient },
+        ),
       );
 
       const requestCall = fetchMock.calls('/api/posts/new')[0];
@@ -2971,12 +3169,15 @@ describe('Mutation', () => {
         }
       `;
 
-      await toPromise<Result>(
-        execute(link, {
-          operationName: 'publishPost',
-          query: createPostMutation,
-          variables: { input: post },
-        }),
+      await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: createPostMutation,
+            variables: { input: post },
+          },
+          { client: dummyClient },
+        ),
       );
       const requestCall = fetchMock.calls('/api/posts/newComplexPost')[0];
       expect(requestCall[1].headers.get('content-type')).toEqual(
@@ -3023,12 +3224,15 @@ describe('Mutation', () => {
         }
       `;
 
-      const response = await toPromise<Result>(
-        execute(link, {
-          operationName: 'publishPost',
-          query: createPostMutation,
-          variables: { input: post },
-        }),
+      const response = await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: createPostMutation,
+            variables: { input: post },
+          },
+          { client: dummyClient },
+        ),
       );
       expect(response.data.publishedPost).toEqual(resultPost);
 
@@ -3069,12 +3273,15 @@ describe('Mutation', () => {
           }
         }
       `;
-      const response = await toPromise<Result>(
-        execute(link, {
-          operationName: 'publishPost',
-          query: createPostMutation,
-          variables: { someApiWithACustomBodyKey: { title: post.title } },
-        }),
+      const response = await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: createPostMutation,
+            variables: { someApiWithACustomBodyKey: { title: post.title } },
+          },
+          { client: dummyClient },
+        ),
       );
       expect(response.data.publishedPost).toEqual(resultPost);
 
@@ -3118,15 +3325,18 @@ describe('Mutation', () => {
         return 'MAGIC_PREFIX' + JSON.stringify(args.input);
       }
 
-      const response = await toPromise<Result>(
-        execute(link, {
-          operationName: 'publishPost',
-          query: createPostMutation,
-          variables: {
-            input: { title: post.title },
-            customBuilder: fakeEncryption,
+      const response = await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: createPostMutation,
+            variables: {
+              input: { title: post.title },
+              customBuilder: fakeEncryption,
+            },
           },
-        }),
+          { client: dummyClient },
+        ),
       );
       expect(response.data.publishedPost).toEqual(resultPost);
 
@@ -3163,12 +3373,15 @@ describe('Mutation', () => {
         }
       `;
 
-      const response = await toPromise<Result>(
-        execute(link, {
-          operationName: 'getPost',
-          query: getPostQuery,
-          variables: { id: '1' },
-        }),
+      const response = await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: getPostQuery,
+            variables: { id: '1' },
+          },
+          { client: dummyClient },
+        ),
       );
 
       expect(response.data.post).toEqual(resultPost);
@@ -3193,11 +3406,14 @@ describe('Mutation', () => {
         }
       `;
 
-      await toPromise<Result>(
-        execute(link, {
-          operationName: 'createPost',
-          query: createPostMutation,
-        }),
+      await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: createPostMutation,
+          },
+          { client: dummyClient },
+        ),
       ).catch(e =>
         expect(e).toEqual(
           new Error(
@@ -3252,12 +3468,15 @@ describe('Mutation', () => {
         }
       `;
 
-      await toPromise<Result>(
-        execute(link, {
-          operationName: 'publishPost',
-          query: createPostMutation,
-          variables: { input: post },
-        }),
+      await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: createPostMutation,
+            variables: { input: post },
+          },
+          { client: dummyClient },
+        ),
       );
 
       const requestCall = fetchMock.calls('/api/posts/newComplexPost')[0];
@@ -3323,12 +3542,15 @@ describe('Mutation', () => {
         }
       `;
 
-      await toPromise<Result>(
-        execute(link, {
-          operationName: 'publishPost',
-          query: createPostMutation,
-          variables: { input: post },
-        }),
+      await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: createPostMutation,
+            variables: { input: post },
+          },
+          { client: dummyClient },
+        ),
       );
 
       const requestCall = fetchMock.calls('/api/posts/newComplexPost')[0];
@@ -3412,12 +3634,15 @@ describe('Mutation', () => {
         }
       `;
 
-      await toPromise<Result>(
-        execute(link, {
-          operationName: 'publishPost',
-          query: createPostMutation,
-          variables: { input: post, bodySerializer: constSerializer },
-        }),
+      await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: createPostMutation,
+            variables: { input: post, bodySerializer: constSerializer },
+          },
+          { client: dummyClient },
+        ),
       );
 
       const requestCall = fetchMock.calls('/api/posts/newComplexPost')[0];
@@ -3512,12 +3737,15 @@ describe('Mutation', () => {
         }
       `;
 
-      await toPromise<Result>(
-        execute(link, {
-          operationName: 'publishPost',
-          query: createPostMutation,
-          variables: { input: post },
-        }),
+      await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: createPostMutation,
+            variables: { input: post },
+          },
+          { client: dummyClient },
+        ),
       );
 
       const requestCall = fetchMock.calls('/api/posts/newComplexPost')[0];
@@ -3554,12 +3782,15 @@ describe('Mutation', () => {
 
       const post = { id: '1' };
 
-      return toPromise<Result>(
-        execute(link, {
-          operationName: 'publishPost',
-          query: createPostMutation,
-          variables: { input: post },
-        }),
+      return firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: createPostMutation,
+            variables: { input: post },
+          },
+          { client: dummyClient },
+        ),
       ).catch(e =>
         expect(e).toEqual(
           new Error(
@@ -3576,7 +3807,10 @@ describe('validateRequestMethodForOperationType', () => {
     it('throws because it is not supported yet', () => {
       expect.assertions(1);
       expect(() =>
-        validateRequestMethodForOperationType('GIBBERISH', 'mutation'),
+        validateRequestMethodForOperationType(
+          'GIBBERISH',
+          OperationTypeNode.MUTATION,
+        ),
       ).toThrowError('"mutation" operations do not support that HTTP-verb');
     });
   });
@@ -3584,7 +3818,10 @@ describe('validateRequestMethodForOperationType', () => {
     it('throws because it is not supported yet', () => {
       expect.assertions(1);
       expect(() =>
-        validateRequestMethodForOperationType('GET', 'subscription'),
+        validateRequestMethodForOperationType(
+          'GET',
+          OperationTypeNode.SUBSCRIPTION,
+        ),
       ).toThrowError('A "subscription" operation is not supported yet.');
     });
   });
@@ -3615,12 +3852,15 @@ describe('export directive', () => {
     `;
 
     try {
-      await toPromise<Result>(
-        execute(link, {
-          operationName: 'postTitle',
-          query: postTagWithoutExport,
-          variables: { id: '1' },
-        }),
+      await firstValueFrom<Result>(
+        execute(
+          link,
+          {
+            query: postTagWithoutExport,
+            variables: { id: '1' },
+          },
+          { client: dummyClient },
+        ),
       );
     } catch (e) {
       expect(e.message).toBe(
@@ -3653,12 +3893,15 @@ describe('export directive', () => {
       }
     `;
 
-    const { data } = await toPromise<Result>(
-      execute(link, {
-        operationName: 'postTitle',
-        query: postTagExport,
-        variables: { id: '1' },
-      }),
+    const { data } = await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: postTagExport,
+          variables: { id: '1' },
+        },
+        { client: dummyClient },
+      ),
     );
 
     expect(data.post.tag).toEqual({ ...tag, __typename: 'Tag' });
@@ -3692,12 +3935,15 @@ describe('export directive', () => {
       }
     `;
 
-    const { data } = await toPromise<Result>(
-      execute(link, {
-        operationName: 'postTitle',
-        query: postTagExport,
-        variables: { id: '1' },
-      }),
+    const { data } = await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: postTagExport,
+          variables: { id: '1' },
+        },
+        { client: dummyClient },
+      ),
     );
 
     expect(data.post.tag).toEqual({ ...tag, __typename: 'Tag' });
@@ -3771,11 +4017,14 @@ describe('export directive', () => {
       }
     `;
 
-    const { data } = await toPromise<Result>(
-      execute(link, {
-        operationName: 'userPostsWithTagDetails',
-        query: userPostsWithTagDetails,
-      }),
+    const { data } = await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: userPostsWithTagDetails,
+        },
+        { client: dummyClient },
+      ),
     );
 
     expect(data.user.posts[0].tags[0].details.message).toEqual(
@@ -3816,12 +4065,15 @@ describe('export directive', () => {
       }
     `;
 
-    const { data } = await toPromise<Result>(
-      execute(link, {
-        operationName: 'getPostWithCommentsAndDetails',
-        query: getPostWithCommentsAndDetails,
-        variables: { id: '1' },
-      }),
+    const { data } = await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: getPostWithCommentsAndDetails,
+          variables: { id: '1' },
+        },
+        { client: dummyClient },
+      ),
     );
 
     expect(data.post.comments[0].details[0]).toEqual({
@@ -3858,7 +4110,7 @@ describe('Apollo client integration', () => {
       link,
     });
 
-    const { data }: ApolloQueryResult<any> = await client.query({
+    const { data }: ApolloLink.Result<any> = await client.query({
       query: postTagExport,
     });
 
@@ -3894,7 +4146,7 @@ describe('Apollo client integration', () => {
     expect(fetchMock.lastCall()[1].body).toBeUndefined();
   });
 
-  it('treats absent response fields as optional', async done => {
+  it('treats absent response fields as optional', async () => {
     // Discovered in: https://github.com/apollographql/apollo-link-rest/issues/74
 
     const link = new RestLink({ uri: '/api' });
@@ -3923,11 +4175,14 @@ describe('Apollo client integration', () => {
       }
     `;
 
-    const { data } = await toPromise<Result>(
-      execute(link, {
-        operationName: 'postWithContent',
-        query: postTitleQuery,
-      }),
+    const { data } = await firstValueFrom<Result>(
+      execute(
+        link,
+        {
+          query: postTitleQuery,
+        },
+        { client: dummyClient },
+      ),
     );
 
     expect(data.post.unfairCriticism).toBeNull();
@@ -3937,17 +4192,14 @@ describe('Apollo client integration', () => {
       link,
     });
 
-    const { data: data2 }: ApolloQueryResult<any> = await client.query({
+    const { data: data2 }: ApolloLink.Result<any> = await client.query({
       query: postTitleQuery,
     });
     expect(data2.post.unfairCriticism).toBeNull();
 
-    const errorLink = onError(opts => {
+    const errorLink = new ErrorLink(opts => {
       console.error(opts);
-      const { networkError, graphQLErrors } = opts;
-      expect(
-        networkError || (graphQLErrors && graphQLErrors.length > 0),
-      ).toBeTruthy();
+      expect(opts.error).toBeTruthy();
     });
     const combinedLink = ApolloLink.from([
       new RestLink({
@@ -3979,27 +4231,24 @@ describe('Apollo client integration', () => {
       const result = await client3.query({
         query: postTitleQuery,
       });
-      const { errors } = result;
-      if (errors && errors.length > 0) {
+      if (result.error) {
         throw new Error('All is well, errors were thrown as expected');
       }
-      done.fail('query should throw some sort of error');
-    } catch (error) {
-      done();
-    }
+      throw new Error('query should throw some sort of error');
+    } catch (error) {}
   });
 
-  it('can catch HTTP Status errors', async done => {
+  it('can catch HTTP Status errors', async () => {
     const link = new RestLink({ uri: '/api' });
 
     const status = 403;
 
     // setup onError link
-    const errorLink = onError(opts => {
-      const { networkError } = opts;
-      if (networkError != null) {
+    const errorLink = new ErrorLink(opts => {
+      const { error } = opts;
+      if (ServerError.is(error)) {
         //console.debug(`[Network error]: ${networkError}`);
-        const { statusCode } = networkError as RestLink.ServerError;
+        const { statusCode } = error;
         expect(statusCode).toEqual(status);
       }
     });
@@ -4019,10 +4268,8 @@ describe('Apollo client integration', () => {
       await client.query({
         query: sampleQuery,
       });
-      done.fail('query should throw a network error');
-    } catch (error) {
-      done();
-    }
+      throw new Error('query should throw a network error');
+    } catch (error) {}
   });
 
   it('supports being cancelled and does not throw', done => {
@@ -4042,7 +4289,11 @@ describe('Apollo client integration', () => {
       customFetch: customFetch as any,
     });
 
-    const sub = execute(link, { query: sampleQuery }).subscribe({
+    const sub = execute(
+      link,
+      { query: sampleQuery },
+      { client: dummyClient },
+    ).subscribe({
       next: () => {
         done.fail('result should not have been called');
       },
@@ -4087,7 +4338,7 @@ describe('Playing nice with others', () => {
     fetchMock.get('/api/posts', posts);
     fetchMock.post('/graphql', authors);
     const { restLink, httpLink } = buildLinks();
-    const link = from([restLink, httpLink]);
+    const link = ApolloLink.from([restLink, httpLink]);
     const restQuery = gql`
       query {
         people @rest(type: "[Post]", path: "/posts") {
@@ -4112,14 +4363,14 @@ describe('Playing nice with others', () => {
         }
       }
     `;
-    const { data: restData } = await toPromise<Result>(
-      execute(link, { operationName: 'restQuery', query: restQuery }),
+    const { data: restData } = await firstValueFrom<Result>(
+      execute(link, { query: restQuery }, { client: dummyClient }),
     );
-    const { data: httpData } = await toPromise<Result>(
-      execute(link, { operationName: 'httpData', query: httpQuery }),
+    const { data: httpData } = await firstValueFrom<Result>(
+      execute(link, { query: httpQuery }, { client: dummyClient }),
     );
-    const { data: combinedData } = await toPromise<Result>(
-      execute(link, { operationName: 'combinedQuery', query: combinedQuery }),
+    const { data: combinedData } = await firstValueFrom<Result>(
+      execute(link, { query: combinedQuery }, { client: dummyClient }),
     );
     expect(restData).toEqual({
       people: [
@@ -4144,7 +4395,7 @@ describe('Playing nice with others', () => {
     fetchMock.post('/graphql', authors);
 
     const { restLink, httpLink } = buildLinks();
-    const link = from([restLink, httpLink]);
+    const link = ApolloLink.from([restLink, httpLink]);
 
     const combinedQuery = gql`
       query {
@@ -4157,8 +4408,8 @@ describe('Playing nice with others', () => {
       }
     `;
 
-    const { data: combinedData } = await toPromise<Result>(
-      execute(link, { operationName: 'combinedQuery', query: combinedQuery }),
+    const { data: combinedData } = await firstValueFrom<Result>(
+      execute(link, { query: combinedQuery }, { client: dummyClient }),
     );
 
     expect(combinedData).toEqual({
@@ -4183,7 +4434,7 @@ describe('Playing nice with others', () => {
     fetchMock.get('/api/posts', posts);
     fetchMock.post('/graphql', authorErrors);
     const { restLink, httpLink } = buildLinks();
-    const link = from([restLink, httpLink]);
+    const link = ApolloLink.from([restLink, httpLink]);
 
     const combinedQuery = gql`
       query {
@@ -4196,8 +4447,8 @@ describe('Playing nice with others', () => {
       }
     `;
 
-    const { data: combinedData, errors } = await toPromise<Result>(
-      execute(link, { operationName: 'combinedQuery', query: combinedQuery }),
+    const { data: combinedData, errors } = await firstValueFrom<Result>(
+      execute(link, { query: combinedQuery }, { client: dummyClient }),
     );
 
     expect(combinedData).toEqual({

--- a/src/restLink.ts
+++ b/src/restLink.ts
@@ -1,35 +1,29 @@
 import {
-  OperationTypeNode,
-  OperationDefinitionNode,
-  FragmentDefinitionNode,
-  // Query Nodes
   DirectiveNode,
   DocumentNode,
   FieldNode,
+  FragmentDefinitionNode,
+  OperationDefinitionNode,
+  OperationTypeNode,
   SelectionSetNode,
 } from 'graphql';
+import { Observable } from '@apollo/client/core';
+import { ApolloLink } from '@apollo/client';
 import {
-  ApolloLink,
-  Observable,
-  Operation,
-  NextLink,
-  FetchResult,
-} from '@apollo/client/core';
-import {
-  hasDirectives,
-  getMainDefinition,
-  getFragmentDefinitions,
-  createFragmentMap,
-  addTypenameToDocument,
-  FragmentMap,
-  isField,
-  isInlineFragment,
-  resultKeyNameFromField,
   checkDocument,
+  createFragmentMap,
+  FragmentMap,
+  getFragmentDefinitions,
+  getMainDefinition,
+  hasDirectives,
+  isField,
   removeDirectivesFromDocument,
-} from '@apollo/client/utilities';
-import { graphql } from './utils/graphql';
+  resultKeyNameFromField,
+} from '@apollo/client/utilities/internal';
+import { graphql, isInlineFragment } from './utils/graphql';
 import * as qs from 'qs';
+import { addTypenameToDocument } from '@apollo/client/utilities';
+import { mergeMap, of } from 'rxjs';
 
 export type DirectiveInfo = {
   [fieldName: string]: { [argName: string]: any };
@@ -709,7 +703,7 @@ export const normalizeHeaders = (
   if (headers instanceof Headers) {
     return headers;
   } else {
-    return new Headers(headers || {});
+    return new Headers((headers as [string, string][]) || {});
   }
 };
 
@@ -774,19 +768,19 @@ export const validateRequestMethodForOperationType = (
   operationType: OperationTypeNode,
 ): void => {
   switch (operationType) {
-    case 'query':
+    case OperationTypeNode.QUERY:
       if (SUPPORTED_HTTP_VERBS.indexOf(method.toUpperCase()) !== -1) {
         return;
       }
       throw new Error(
         `A "query" operation can only support "GET" requests but got "${method}".`,
       );
-    case 'mutation':
+    case OperationTypeNode.MUTATION:
       if (SUPPORTED_HTTP_VERBS.indexOf(method.toUpperCase()) !== -1) {
         return;
       }
       throw new Error('"mutation" operations do not support that HTTP-verb');
-    case 'subscription':
+    case OperationTypeNode.SUBSCRIPTION:
       throw new Error('A "subscription" operation is not supported yet.');
     default:
       const _exhaustiveCheck: never = operationType;
@@ -1063,10 +1057,13 @@ const resolver: Resolver = async (
     }
 
     body = serializedBody.body;
-    overrideHeaders = new Headers(serializedBody.headers);
+    overrideHeaders = new Headers(serializedBody.headers as [string, string][]);
   }
 
-  validateRequestMethodForOperationType(method, operationType || 'query');
+  validateRequestMethodForOperationType(
+    method,
+    operationType || OperationTypeNode.QUERY,
+  );
 
   const requestParams = {
     method,
@@ -1311,9 +1308,9 @@ export class RestLink extends ApolloLink {
   }
 
   public request(
-    operation: Operation,
-    forward?: NextLink,
-  ): Observable<FetchResult> | null {
+    operation: ApolloLink.Operation,
+    forward?: ApolloLink.ForwardFunction,
+  ): Observable<ApolloLink.Result> {
     const { query, variables, getContext, setContext } = operation;
     const context: LinkChainContext | any = getContext() as any;
     const isRestQuery = hasDirectives(['rest'], query);
@@ -1375,40 +1372,42 @@ export class RestLink extends ApolloLink {
       responseTransformer: this.responseTransformer,
     };
     const resolverOptions = {};
-    let obs;
+    let obs: Observable<ApolloLink.Result>;
     if (nonRest && forward) {
       operation.query = nonRest;
       obs = forward(operation);
-    } else obs = Observable.of({ data: {} });
+    } else obs = of({ data: {} });
 
-    return obs.flatMap(
-      ({ data, errors }) =>
-        new Observable(observer => {
-          graphql(
-            resolver,
-            queryWithTypename,
-            data,
-            requestContext,
-            variables,
-            resolverOptions,
-          )
-            .then(data => {
-              setContext({
-                restResponses: (context.restResponses || []).concat(
-                  requestContext.responses,
-                ),
+    return obs.pipe(
+      mergeMap(
+        ({ data, errors }) =>
+          new Observable(observer => {
+            graphql(
+              resolver,
+              queryWithTypename,
+              data,
+              requestContext,
+              variables,
+              resolverOptions,
+            )
+              .then(data => {
+                setContext({
+                  restResponses: (context.restResponses || []).concat(
+                    requestContext.responses,
+                  ),
+                });
+                observer.next({ data, errors });
+                observer.complete();
+              })
+              .catch(err => {
+                if (err.name === 'AbortError') return;
+                if (err.result && err.result.errors) {
+                  observer.next(err.result);
+                }
+                observer.error(err);
               });
-              observer.next({ data, errors });
-              observer.complete();
-            })
-            .catch(err => {
-              if (err.name === 'AbortError') return;
-              if (err.result && err.result.errors) {
-                observer.next(err.result);
-              }
-              observer.error(err);
-            });
-        }),
+          }),
+      ),
     );
   }
 }

--- a/src/utils/graphql.ts
+++ b/src/utils/graphql.ts
@@ -8,25 +8,25 @@
 */
 
 import {
+  DirectiveNode,
   DocumentNode,
-  SelectionSetNode,
   FieldNode,
   FragmentDefinitionNode,
   InlineFragmentNode,
-  DirectiveNode,
+  SelectionNode,
+  SelectionSetNode,
 } from 'graphql';
 
 import {
-  getMainDefinition,
-  getFragmentDefinitions,
-  createFragmentMap,
-  shouldInclude,
-  isField,
-  isInlineFragment,
-  resultKeyNameFromField,
   argumentsObjectFromField,
+  createFragmentMap,
   FragmentMap,
-} from '@apollo/client/utilities';
+  getFragmentDefinitions,
+  getMainDefinition,
+  isField,
+  resultKeyNameFromField,
+  shouldInclude,
+} from '@apollo/client/utilities/internal';
 
 import { DirectiveInfo, ExecInfo, Resolver } from '../restLink';
 
@@ -261,4 +261,10 @@ function executeSubSelectedArray(field, result, execContext) {
       return executeSelectionSet(field.selectionSet, item, execContext);
     }),
   );
+}
+
+export function isInlineFragment(
+  selection: SelectionNode,
+): selection is InlineFragmentNode {
+  return selection.kind === 'InlineFragment';
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ESNext",
     "lib": ["es6", "dom"],
     "module": "es2015",
     "moduleResolution": "node",


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [ ] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

Hi! I quickly spent an hour trying to get this lib to work with Apollo v4 since I need it in some projects.

Of the thousands way this could have been done, I chose one of the quickest and far from cleanest.

I'm just putting this here in case anyone needs it! And if that can help to do a clean update of this lib.

The goal here was just to have the lib work with Apollo v4, have the unit tests green, and be able to build.